### PR TITLE
Refactored Weapon to be MonoBehaviour

### DIFF
--- a/Assets/Scripts/Enemy/EnemyFactory.cs
+++ b/Assets/Scripts/Enemy/EnemyFactory.cs
@@ -56,6 +56,9 @@ public class EnemyFactory
         // TODO: change default vector to dynamically adjust height of enemy spawn so they don't spawn under the ground.
         enemyTransform.position = position + new Vector3(0, 1, 0);
         
+        Weapon w = newEnemyObject.AddComponent<Weapon>();
+        w.Initialize(new BulletAttackBehaviour(EntityType.ENEMY), 1f);
+        
         // TODO: Determine whether we're including EnemyBehvaviour in the prefab, or adding it as component.
         // I'll just go with adding it for now.
         EnemyBehaviour eb = EnemyBehaviour.AddToGameObject(
@@ -64,7 +67,7 @@ public class EnemyFactory
             _defaultFunc, 
             Globals.DirectTargeting, 
             _defaultMove, 
-            new Weapon(new BulletAttackBehaviour(EntityType.ENEMY), 1f));
+            w);
         if (_enemySetups.ContainsKey(enemyName)) _enemySetups[enemyName](eb);
 
         return newEnemyObject;

--- a/Assets/Scripts/Enemy/EnemyFactory.cs
+++ b/Assets/Scripts/Enemy/EnemyFactory.cs
@@ -56,8 +56,8 @@ public class EnemyFactory
         // TODO: change default vector to dynamically adjust height of enemy spawn so they don't spawn under the ground.
         enemyTransform.position = position + new Vector3(0, 1, 0);
         
-        Weapon w = newEnemyObject.AddComponent<Weapon>();
-        w.Initialize(new BulletAttackBehaviour(EntityType.ENEMY), 1f);
+        Weapon enemyWeapon = newEnemyObject.AddComponent<Weapon>();
+        enemyWeapon.Initialize(new BulletAttackBehaviour(EntityType.ENEMY), 1f);
         
         // TODO: Determine whether we're including EnemyBehvaviour in the prefab, or adding it as component.
         // I'll just go with adding it for now.
@@ -67,7 +67,7 @@ public class EnemyFactory
             _defaultFunc, 
             Globals.DirectTargeting, 
             _defaultMove, 
-            w);
+            enemyWeapon);
         if (_enemySetups.ContainsKey(enemyName)) _enemySetups[enemyName](eb);
 
         return newEnemyObject;

--- a/Assets/Scripts/Player/PlayerControls.cs
+++ b/Assets/Scripts/Player/PlayerControls.cs
@@ -17,7 +17,10 @@ public class PlayerControls : MonoBehaviour
         Cursor.lockState = CursorLockMode.Locked;
         _player = GameObject.FindWithTag("Player");
         _camera = Camera.main;
-        _weapon = new Weapon(new BulletAttackBehaviour(EntityType.PLAYER));
+        
+        
+        _weapon = _player.AddComponent<Weapon>();
+        _weapon.Initialize(new BulletAttackBehaviour(EntityType.PLAYER));
     }
 
     // Update is called once per frame

--- a/Assets/Scripts/Weapons/Weapon.cs
+++ b/Assets/Scripts/Weapons/Weapon.cs
@@ -3,8 +3,9 @@ using System.Collections.Generic;
 using UnityEngine;
 
 //To be attached to Player or Enemy Objects
-public class Weapon
+public class Weapon : MonoBehaviour
 {
+    private bool _initialized = false;
     Dictionary<string, bool> _firingBehavior = new Dictionary<string, bool>()
     {
         { "singleShot", true }, // singleShot == !repeater
@@ -18,12 +19,17 @@ public class Weapon
     int _currentMagazine;
     double lastShot = 0;
 
-    public Weapon(AbstractAttackBehaviour attackBehaviour, float fireRate = 0.1f, int magSize = 1)
+    public bool Initialize(AbstractAttackBehaviour attackBehaviour, float fireRate = 0.1f, int magSize = 1)
     {
+        if (_initialized) return false;
+        _initialized = true;
+        
         _attackBehaviour = attackBehaviour;
         _fireRate = fireRate; 
         _magazineSize = magSize;
         _currentMagazine = magSize;
+
+        return true;
     }
 
     public void Attack(Vector3 position, Vector3 direction)


### PR DESCRIPTION
Weapon should be a MonoBehaviour to allow for easy static access to the object.
If we wanted to get the Weapon object from a GameObject previously, we had to do either player.GetComponent<PlayerControls>()._weapon or enemy.GetComponent<EnemyBehaviour>()._weapon. With this, we can just do gameObject.GetComponent<Weapon>();