### PR TITLE
Stat Power ups + Power up framework

### DIFF
--- a/Assets/Scenes/LevelPrototypeScene.unity
+++ b/Assets/Scenes/LevelPrototypeScene.unity
@@ -2496,6 +2496,23 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2685706481241577166, guid: bece59729368be64c8afc5b05a64d0a3, type: 3}
   m_PrefabInstance: {fileID: 1121111274}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1889198380 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5841979810881545756, guid: b48c293e05f83a84cb33d1d6c25fc4a7, type: 3}
+  m_PrefabInstance: {fileID: 5841979812143880682}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1889198381
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1889198380}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3dace3ca18fd74e49b9e84368494cd8d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1895119880
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Globals.cs
+++ b/Assets/Scripts/Globals.cs
@@ -4,9 +4,9 @@ using UnityEngine;
 
 public class Globals
 {
-	public static Dictionary<PowerUpType, AbstractPowerUp> AbstractPowerUpDictionary = new Dictionary<PowerUpType, AbstractPowerUp>
+	public static Dictionary<PowerUpType, StatPowerUp> StatPowerUpDictionary = new Dictionary<PowerUpType, StatPowerUp>
 	{{PowerUpType.DAMAGE, new StatPowerUp(5f)},
-	{PowerUpType.FIRERATE, new StatPowerUp(0.1f)},
+	{PowerUpType.FIRERATE, new StatPowerUp(-0.04f)},
 	{PowerUpType.RELOADSPD, new StatPowerUp(1f)},
 	{PowerUpType.CLIPSIZE, new StatPowerUp(2f)},
 	{PowerUpType.ADRENALIN, new StatPowerUp(0.9f)}

--- a/Assets/Scripts/Globals.cs
+++ b/Assets/Scripts/Globals.cs
@@ -9,16 +9,8 @@ public class Globals
 	{PowerUpType.FIRERATE, new StatPowerUp(-0.04f)},
 	{PowerUpType.RELOADSPD, new StatPowerUp(1f)},
 	{PowerUpType.CLIPSIZE, new StatPowerUp(2f)},
-	{PowerUpType.ADRENALIN, new StatPowerUp(0.9f)}
+	{PowerUpType.ADRENALIN, new StatPowerUp(0.15f)}
 	};
-
-	// public static Dictionary<PowerUpType, float> StatModifierDictionary = new Dictionary<PowerUpType, float>
-	// {{PowerUpType.DAMAGE, new StatPowerUp(5f)},
-	// {PowerUpType.FIRERATE, new StatPowerUp(0.1f)},
-	// {PowerUpType.RELOADSPD, new StatPowerUp(1f)},
-	// {PowerUpType.CLIPSIZE, new StatPowerUp(2f)},
-	// {PowerUpType.ADRENALIN, new StatPowerUp(0.9f)}
-	// };
 
 	public static Vector3 DirectTargeting(Transform from, Transform to) {
 		Vector3 direction = (to.position - from.position).normalized;

--- a/Assets/Scripts/Globals.cs
+++ b/Assets/Scripts/Globals.cs
@@ -4,6 +4,22 @@ using UnityEngine;
 
 public class Globals
 {
+	public static Dictionary<PowerUpType, AbstractPowerUp> AbstractPowerUpDictionary = new Dictionary<PowerUpType, AbstractPowerUp>
+	{{PowerUpType.DAMAGE, new StatPowerUp(5f)},
+	{PowerUpType.FIRERATE, new StatPowerUp(0.1f)},
+	{PowerUpType.RELOADSPD, new StatPowerUp(1f)},
+	{PowerUpType.CLIPSIZE, new StatPowerUp(2f)},
+	{PowerUpType.ADRENALIN, new StatPowerUp(0.9f)}
+	};
+
+	// public static Dictionary<PowerUpType, float> StatModifierDictionary = new Dictionary<PowerUpType, float>
+	// {{PowerUpType.DAMAGE, new StatPowerUp(5f)},
+	// {PowerUpType.FIRERATE, new StatPowerUp(0.1f)},
+	// {PowerUpType.RELOADSPD, new StatPowerUp(1f)},
+	// {PowerUpType.CLIPSIZE, new StatPowerUp(2f)},
+	// {PowerUpType.ADRENALIN, new StatPowerUp(0.9f)}
+	// };
+
 	public static Vector3 DirectTargeting(Transform from, Transform to) {
 		Vector3 direction = (to.position - from.position).normalized;
 		return direction;
@@ -13,4 +29,13 @@ public class Globals
 public enum EntityType {
 	PLAYER,
 	ENEMY
+}
+
+public enum PowerUpType{
+	NONE,
+	DAMAGE,
+	FIRERATE,
+	RELOADSPD,
+	CLIPSIZE,
+	ADRENALIN
 }

--- a/Assets/Scripts/PowerUps.meta
+++ b/Assets/Scripts/PowerUps.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6f89bbefe413a40488b438767ee01d53
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PowerUps/AbstractBulletPowerUp.cs
+++ b/Assets/Scripts/PowerUps/AbstractBulletPowerUp.cs
@@ -2,12 +2,8 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class AbstractBulletPowerUp : AbstractPowerUp
+public abstract class AbstractBulletPowerUp : AbstractPowerUp
 {
-    public override Vector3[] applyPowerUp(Vector3[] direction){
-        return new Vector3[0];
-    }
-    
 }
 
 public class TargetingBulletPowerUp : AbstractBulletPowerUp

--- a/Assets/Scripts/PowerUps/AbstractBulletPowerUp.cs
+++ b/Assets/Scripts/PowerUps/AbstractBulletPowerUp.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AbstractBulletPowerUp : AbstractPowerUp
+{
+
+}
+
+public class TargetingBulletPowerUp : AbstractBulletPowerUp
+{
+
+}
+
+public class OnHitBulletPowerUp : AbstractBulletPowerUp
+{
+    
+}

--- a/Assets/Scripts/PowerUps/AbstractBulletPowerUp.cs
+++ b/Assets/Scripts/PowerUps/AbstractBulletPowerUp.cs
@@ -4,15 +4,26 @@ using UnityEngine;
 
 public class AbstractBulletPowerUp : AbstractPowerUp
 {
-
+    public override Vector3[] applyPowerUp(Vector3[] direction){
+        return new Vector3[0];
+    }
+    
 }
 
 public class TargetingBulletPowerUp : AbstractBulletPowerUp
 {
-
+    public override Vector3[] applyPowerUp(Vector3[] direction)
+    {
+        return new Vector3[0];
+    }
+    
 }
 
 public class OnHitBulletPowerUp : AbstractBulletPowerUp
 {
+    public override Vector3[] applyPowerUp(Vector3[] direction)
+    {
+        return new Vector3[0];
+    }
     
 }

--- a/Assets/Scripts/PowerUps/AbstractBulletPowerUp.cs.meta
+++ b/Assets/Scripts/PowerUps/AbstractBulletPowerUp.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0dfe3cdec2703c47b5af130d22e0ffb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PowerUps/AbstractFiringPowerUp.cs
+++ b/Assets/Scripts/PowerUps/AbstractFiringPowerUp.cs
@@ -2,7 +2,11 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class ShotgunFiringPowerUp : AbstractPowerUp
+public abstract class AbstractFiringPowerUp : AbstractPowerUp
+{
+}
+
+public class ShotgunFiringPowerUp : AbstractFiringPowerUp
 {
     public override Vector3[] applyPowerUp(Vector3[] direction)
     {
@@ -11,7 +15,7 @@ public class ShotgunFiringPowerUp : AbstractPowerUp
 
 }
 
-public class RepeaterFiringPowerUp : AbstractPowerUp
+public class RepeaterFiringPowerUp : AbstractFiringPowerUp
 {
     public override Vector3[] applyPowerUp(Vector3[] direction)
     {
@@ -20,7 +24,7 @@ public class RepeaterFiringPowerUp : AbstractPowerUp
 
 }
 
-public class AutomaticFiringPowerUp : AbstractPowerUp
+public class AutomaticFiringPowerUp : AbstractFiringPowerUp
 {
     public override Vector3[] applyPowerUp(Vector3[] direction)
     {
@@ -29,7 +33,7 @@ public class AutomaticFiringPowerUp : AbstractPowerUp
     
 }
 
-public class ChargeShotFiringPowerUp : AbstractPowerUp
+public class ChargeShotFiringPowerUp : AbstractFiringPowerUp
 {
     public override Vector3[] applyPowerUp(Vector3[] direction)
     {

--- a/Assets/Scripts/PowerUps/AbstractFiringPowerUp.cs
+++ b/Assets/Scripts/PowerUps/AbstractFiringPowerUp.cs
@@ -2,13 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public abstract class AbstractFiringPowerUp : AbstractPowerUp
-{
-    public abstract Vector3[] applyPowerUp(Vector3[] direction);
-
-}
-
-public class ShotgunFiringPowerUp : AbstractFiringPowerUp
+public class ShotgunFiringPowerUp : AbstractPowerUp
 {
     public override Vector3[] applyPowerUp(Vector3[] direction)
     {
@@ -17,26 +11,29 @@ public class ShotgunFiringPowerUp : AbstractFiringPowerUp
 
 }
 
-public class RepeaterFiringPowerUp : AbstractFiringPowerUp
+public class RepeaterFiringPowerUp : AbstractPowerUp
 {
     public override Vector3[] applyPowerUp(Vector3[] direction)
     {
         return new Vector3[0];
     }
+
 }
 
-public class AutomaticFiringPowerUp : AbstractFiringPowerUp
+public class AutomaticFiringPowerUp : AbstractPowerUp
 {
     public override Vector3[] applyPowerUp(Vector3[] direction)
     {
         return new Vector3[0];
     }
+    
 }
 
-public class ChargeShotFiringPowerUp : AbstractFiringPowerUp
+public class ChargeShotFiringPowerUp : AbstractPowerUp
 {
     public override Vector3[] applyPowerUp(Vector3[] direction)
     {
         return new Vector3[0];
     }
+    
 }

--- a/Assets/Scripts/PowerUps/AbstractFiringPowerUp.cs
+++ b/Assets/Scripts/PowerUps/AbstractFiringPowerUp.cs
@@ -1,0 +1,42 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public abstract class AbstractFiringPowerUp : AbstractPowerUp
+{
+    public abstract Vector3[] applyPowerUp(Vector3[] direction);
+
+}
+
+public class ShotgunFiringPowerUp : AbstractFiringPowerUp
+{
+    public override Vector3[] applyPowerUp(Vector3[] direction)
+    {
+        return new Vector3[0];
+    }
+
+}
+
+public class RepeaterFiringPowerUp : AbstractFiringPowerUp
+{
+    public override Vector3[] applyPowerUp(Vector3[] direction)
+    {
+        return new Vector3[0];
+    }
+}
+
+public class AutomaticFiringPowerUp : AbstractFiringPowerUp
+{
+    public override Vector3[] applyPowerUp(Vector3[] direction)
+    {
+        return new Vector3[0];
+    }
+}
+
+public class ChargeShotFiringPowerUp : AbstractFiringPowerUp
+{
+    public override Vector3[] applyPowerUp(Vector3[] direction)
+    {
+        return new Vector3[0];
+    }
+}

--- a/Assets/Scripts/PowerUps/AbstractFiringPowerUp.cs.meta
+++ b/Assets/Scripts/PowerUps/AbstractFiringPowerUp.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c47bc476ac32fca4f90a37615c2be456
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PowerUps/AbstractPowerUp.cs
+++ b/Assets/Scripts/PowerUps/AbstractPowerUp.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AbstractPowerUp
+{
+    
+}

--- a/Assets/Scripts/PowerUps/AbstractPowerUp.cs
+++ b/Assets/Scripts/PowerUps/AbstractPowerUp.cs
@@ -2,7 +2,9 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class AbstractPowerUp
+public abstract class AbstractPowerUp
 {
-    
+    public float modifier;
+    public abstract Vector3[] applyPowerUp(Vector3[] direction);
+
 }

--- a/Assets/Scripts/PowerUps/AbstractPowerUp.cs.meta
+++ b/Assets/Scripts/PowerUps/AbstractPowerUp.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: caf44343b7f383641b4fb34f618b8e09
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PowerUps/PowerUpManager.cs
+++ b/Assets/Scripts/PowerUps/PowerUpManager.cs
@@ -12,7 +12,6 @@ public class PowerUpManager : MonoBehaviour
     private bool includeNone = false;
     public List<AbstractPowerUp> appliedPowerUps;
 
-    private PlayerControls _player;
     private Weapon _weapon; 
     private AbstractAttackBehaviour _bullet;
 
@@ -22,11 +21,9 @@ public class PowerUpManager : MonoBehaviour
         generatorList = Enumerable.Range(0, System.Enum.GetNames(typeof(PowerUpType)).Length).ToArray();
         powerUpSelectionList = new PowerUpType[numPowerUpOptions];
         appliedPowerUps = new List<AbstractPowerUp>();
-
-        _player = GameObject.FindWithTag("Player").GetComponent<PlayerControls>();
     }
 
-
+    // we generate powerups randomly by shuffling a premade list
     private void generatePowerUps()
     {
         shuffleGeneratorList();
@@ -34,18 +31,21 @@ public class PowerUpManager : MonoBehaviour
         {
             powerUpSelectionList[i] = (PowerUpType)generatorList[i];
 
+            // if we don't want none, we take the next index instead
             if(!includeNone && generatorList[i] == 0)
             {
                 powerUpSelectionList[i] = (PowerUpType)generatorList[3];
             }
         }
 
-        Debug.Log(powerUpSelectionList[0]);
-        Debug.Log(powerUpSelectionList[1]);
-        Debug.Log(powerUpSelectionList[2]);
+        // uncomment to see what powerups are generated
+        // Debug.Log(powerUpSelectionList[0]);
+        // Debug.Log(powerUpSelectionList[1]);
+        // Debug.Log(powerUpSelectionList[2]);
 
     }
 
+    // the knuth shuffle
     private void shuffleGeneratorList()
     {
         Random rand = new Random();
@@ -59,7 +59,7 @@ public class PowerUpManager : MonoBehaviour
         }
     }
 
-    // 
+    // call this method to present the power ups
     public void presentPowerUps()
     {
 
@@ -70,11 +70,10 @@ public class PowerUpManager : MonoBehaviour
         //  the three powerups generated are in powerUpSelectionList
     }
 
-    //
+    // apply stat powerups directly, or add non stat ones to a powerup list
     private void applyPowerUp(PowerUpType type)
     {
         AbstractPowerUp powerUp = Globals.StatPowerUpDictionary[type];
-        Debug.Log(powerUp.modifier);
         switch (type)
         {
             case PowerUpType.NONE:
@@ -99,7 +98,8 @@ public class PowerUpManager : MonoBehaviour
                 Debug.Log("Clip Size PowerUp Applied: " + _weapon._magazineSize);
                 break;                
             case PowerUpType.ADRENALIN:
-                // TODO: apply adrenalin
+                SpeedManager.adrenalinModifier += powerUp.modifier;
+                Debug.Log("Adrenalin PowerUp Applied: " + SpeedManager.adrenalinModifier);
                 break;                
             default:
                 appliedPowerUps.Add(powerUp);

--- a/Assets/Scripts/PowerUps/PowerUpManager.cs
+++ b/Assets/Scripts/PowerUps/PowerUpManager.cs
@@ -1,0 +1,136 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System.Linq;
+using Random = System.Random;
+
+public class PowerUpManager : MonoBehaviour
+{
+    private int numPowerUpOptions = 3;
+    private int[] generatorList;
+    private PowerUpType[] powerUpSelectionList;
+    private bool includeNone = false;
+    public List<AbstractPowerUp> appliedPowerUps;
+
+    private GameObject _player;
+    private Weapon _weapon; 
+    private BulletAttackBehaviour _bullet;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        generatorList = Enumerable.Range(0, System.Enum.GetNames(typeof(PowerUpType)).Length).ToArray();
+        powerUpSelectionList = new PowerUpType[numPowerUpOptions];
+        appliedPowerUps = new List<AbstractPowerUp>();
+        _player = GameObject.FindWithTag("Player");
+
+        // Debug.Log(generatorList[0]);
+        // Debug.Log(generatorList[1]);
+        // Debug.Log(generatorList[2]);
+        // Debug.Log(generatorList[3]);
+        // Debug.Log(generatorList[4]);
+        // Debug.Log(generatorList[5]);
+    }
+
+    // 
+    private void generatePowerUps()
+    {
+        shuffleGeneratorList();
+        for (int i = 0; i < 3; i++)
+        {
+            powerUpSelectionList[i] = (PowerUpType)generatorList[i];
+
+            if(!includeNone && generatorList[i] == 0)
+            {
+                powerUpSelectionList[i] = (PowerUpType)generatorList[3];
+            }
+        }
+
+        // Debug.Log(powerUpSelectionList[0]);
+        // Debug.Log(powerUpSelectionList[1]);
+        // Debug.Log(powerUpSelectionList[2]);
+
+    }
+
+    private void shuffleGeneratorList()
+    {
+        Random rand = new Random();
+        int n = generatorList.Length;
+        while (n > 1)
+        {
+            int k = rand.Next(n--);
+            int temp = generatorList[n];
+            generatorList[n] = generatorList[k];
+            generatorList[k] = temp;
+        }
+
+        // Debug.Log("SHUFFLED");
+        // Debug.Log(generatorList[0]);
+        // Debug.Log(generatorList[1]);
+        // Debug.Log(generatorList[2]);
+        // Debug.Log(generatorList[3]);
+        // Debug.Log(generatorList[4]);
+        // Debug.Log(generatorList[5]);
+    }
+
+    // 
+    public void presentPowerUps()
+    {
+
+        generatePowerUps();
+        StartCoroutine(waitForSelection());
+
+        // TODO: UI - display power up screen to player
+        //  the three powerups generated are in powerUpSelectionList
+    }
+
+    //
+    private void applyPowerUp(PowerUpType type)
+    {
+        AbstractPowerUp powerUp = Globals.AbstractPowerUpDictionary[type];
+        switch (type)
+        {
+            case PowerUpType.NONE:
+                return;
+            case PowerUpType.DAMAGE:
+                // 
+                break;
+            case PowerUpType.FIRERATE:
+                //
+                break;
+            case PowerUpType.RELOADSPD:
+                //
+                break;
+            case PowerUpType.CLIPSIZE:
+                //
+                break;                
+            case PowerUpType.ADRENALIN:
+                //
+                break;                
+            default:
+                appliedPowerUps.Add(Globals.AbstractPowerUpDictionary[type]);
+                break;
+        }
+    }
+
+    IEnumerator waitForSelection()
+    {
+        PowerUpType selection = PowerUpType.NONE;
+        Time.timeScale = 0;
+        while(selection == PowerUpType.NONE)
+        {
+            if (Input.GetKeyDown(KeyCode.Alpha1)){
+                selection = powerUpSelectionList[0];
+            }
+            else if (Input.GetKeyDown(KeyCode.Alpha2)){
+                selection = powerUpSelectionList[1];
+            }
+            else if (Input.GetKeyDown(KeyCode.Alpha3)){
+                selection = powerUpSelectionList[2];
+            }
+            yield return null;
+        }
+        applyPowerUp(selection);
+        Time.timeScale = 1;
+    }
+}

--- a/Assets/Scripts/PowerUps/PowerUpManager.cs
+++ b/Assets/Scripts/PowerUps/PowerUpManager.cs
@@ -13,7 +13,6 @@ public class PowerUpManager : MonoBehaviour
     public List<AbstractPowerUp> appliedPowerUps;
 
     private Weapon _weapon; 
-    private AbstractAttackBehaviour _bullet;
 
     // Start is called before the first frame update
     void Start()

--- a/Assets/Scripts/PowerUps/PowerUpManager.cs
+++ b/Assets/Scripts/PowerUps/PowerUpManager.cs
@@ -12,9 +12,9 @@ public class PowerUpManager : MonoBehaviour
     private bool includeNone = false;
     public List<AbstractPowerUp> appliedPowerUps;
 
-    private GameObject _player;
+    private PlayerControls _player;
     private Weapon _weapon; 
-    private BulletAttackBehaviour _bullet;
+    private AbstractAttackBehaviour _bullet;
 
     // Start is called before the first frame update
     void Start()
@@ -22,17 +22,11 @@ public class PowerUpManager : MonoBehaviour
         generatorList = Enumerable.Range(0, System.Enum.GetNames(typeof(PowerUpType)).Length).ToArray();
         powerUpSelectionList = new PowerUpType[numPowerUpOptions];
         appliedPowerUps = new List<AbstractPowerUp>();
-        _player = GameObject.FindWithTag("Player");
 
-        // Debug.Log(generatorList[0]);
-        // Debug.Log(generatorList[1]);
-        // Debug.Log(generatorList[2]);
-        // Debug.Log(generatorList[3]);
-        // Debug.Log(generatorList[4]);
-        // Debug.Log(generatorList[5]);
+        _player = GameObject.FindWithTag("Player").GetComponent<PlayerControls>();
     }
 
-    // 
+
     private void generatePowerUps()
     {
         shuffleGeneratorList();
@@ -46,9 +40,9 @@ public class PowerUpManager : MonoBehaviour
             }
         }
 
-        // Debug.Log(powerUpSelectionList[0]);
-        // Debug.Log(powerUpSelectionList[1]);
-        // Debug.Log(powerUpSelectionList[2]);
+        Debug.Log(powerUpSelectionList[0]);
+        Debug.Log(powerUpSelectionList[1]);
+        Debug.Log(powerUpSelectionList[2]);
 
     }
 
@@ -63,14 +57,6 @@ public class PowerUpManager : MonoBehaviour
             generatorList[n] = generatorList[k];
             generatorList[k] = temp;
         }
-
-        // Debug.Log("SHUFFLED");
-        // Debug.Log(generatorList[0]);
-        // Debug.Log(generatorList[1]);
-        // Debug.Log(generatorList[2]);
-        // Debug.Log(generatorList[3]);
-        // Debug.Log(generatorList[4]);
-        // Debug.Log(generatorList[5]);
     }
 
     // 
@@ -87,28 +73,36 @@ public class PowerUpManager : MonoBehaviour
     //
     private void applyPowerUp(PowerUpType type)
     {
-        AbstractPowerUp powerUp = Globals.AbstractPowerUpDictionary[type];
+        AbstractPowerUp powerUp = Globals.StatPowerUpDictionary[type];
+        Debug.Log(powerUp.modifier);
         switch (type)
         {
             case PowerUpType.NONE:
                 return;
             case PowerUpType.DAMAGE:
-                // 
+                _weapon = GameObject.FindWithTag("Player").GetComponent<Weapon>();
+                _weapon._attackBehaviour._damage += powerUp.modifier;
+                Debug.Log("Damage PowerUp Applied: " + _weapon._attackBehaviour._damage);
                 break;
             case PowerUpType.FIRERATE:
-                //
+                _weapon = GameObject.FindWithTag("Player").GetComponent<Weapon>();
+                _weapon._fireRate += powerUp.modifier;
+                Debug.Log("Fire Rate PowerUp Applied: " + _weapon._fireRate);
                 break;
             case PowerUpType.RELOADSPD:
-                //
+                _weapon = GameObject.FindWithTag("Player").GetComponent<Weapon>();
+                // TODO: implement reload speed
                 break;
             case PowerUpType.CLIPSIZE:
-                //
+                _weapon = GameObject.FindWithTag("Player").GetComponent<Weapon>();
+                _weapon._magazineSize += (int)powerUp.modifier;
+                Debug.Log("Clip Size PowerUp Applied: " + _weapon._magazineSize);
                 break;                
             case PowerUpType.ADRENALIN:
-                //
+                // TODO: apply adrenalin
                 break;                
             default:
-                appliedPowerUps.Add(Globals.AbstractPowerUpDictionary[type]);
+                appliedPowerUps.Add(powerUp);
                 break;
         }
     }

--- a/Assets/Scripts/PowerUps/PowerUpManager.cs.meta
+++ b/Assets/Scripts/PowerUps/PowerUpManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3dace3ca18fd74e49b9e84368494cd8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PowerUps/StatPowerUp.cs
+++ b/Assets/Scripts/PowerUps/StatPowerUp.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class StatPowerUp : AbstractPowerUp
+{
+    public float modifier;
+
+    public StatPowerUp(float _modifier){
+        modifier = _modifier;
+    }
+
+    public void applyPowerUp(ref float attribute){
+        attribute += modifier;
+    }
+}

--- a/Assets/Scripts/PowerUps/StatPowerUp.cs
+++ b/Assets/Scripts/PowerUps/StatPowerUp.cs
@@ -4,13 +4,11 @@ using UnityEngine;
 
 public class StatPowerUp : AbstractPowerUp
 {
-    public float modifier;
-
     public StatPowerUp(float _modifier){
         modifier = _modifier;
     }
 
-    public void applyPowerUp(ref float attribute){
-        attribute += modifier;
+    public override Vector3[] applyPowerUp(Vector3[] direction){
+        return new Vector3[0];
     }
 }

--- a/Assets/Scripts/PowerUps/StatPowerUp.cs.meta
+++ b/Assets/Scripts/PowerUps/StatPowerUp.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88bd99320b7a023419d213d681eaf471
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SpeedManager.cs
+++ b/Assets/Scripts/SpeedManager.cs
@@ -8,6 +8,7 @@ public class SpeedManager : MonoBehaviour
     public static float playerMovementScaling;
     public static float bulletSpeedScaling;
     public static float enemySpawnScaling;
+    public static float adrenalinModifier = 0f;
 
     void Start() {
         playerMovementScaling = coreSpeed; //TODO: determine player movement ratio based on speed
@@ -20,9 +21,33 @@ public class SpeedManager : MonoBehaviour
     }
 
     static void updateGameObjectSpeed(){
-        playerMovementScaling = coreSpeed;
+        playerMovementScaling = coreSpeed + adrenalin();
         bulletSpeedScaling = coreSpeed;
         enemySpawnScaling = 1 / coreSpeed;
+    }
+
+    static float adrenalin(){
+        // experimental function for adjusting the game speed
+        // the lower hp we are, the more adrenalin does
+        //
+        // change highScale to help out higher hp values
+        // change lowScale to help out lower hp values
+        // 
+        // example with 1 adrenalin powerup:
+        // 10% hp = ~28% game speed equivalent 
+        // 20% hp = ~36% 
+        // 50% hp = ~60%
+        // 80% hp = ~84% 
+        if (adrenalinModifier > 0)
+        {
+            float highScale = 1f + adrenalinModifier;
+            float lowScale = 1.3f + (adrenalinModifier * 3f);
+            float healthDifference = 100f - (100f * coreSpeed);
+
+            return ((0.1f * (highScale * healthDifference)) * lowScale) / 100f;
+        }
+        return 0f;
+
     }
 
 }

--- a/Assets/Scripts/Weapons/Weapon.cs
+++ b/Assets/Scripts/Weapons/Weapon.cs
@@ -13,17 +13,16 @@ public class Weapon : MonoBehaviour
         { "repeater", false }
     };
 
-    AbstractAttackBehaviour _attackBehaviour;
-    float _fireRate; // shots per second
-    int _magazineSize;
+    public AbstractAttackBehaviour _attackBehaviour;
+    public float _fireRate; // shots per second
+    public int _magazineSize;
     int _currentMagazine;
-    double lastShot = 0;
+    public double lastShot = 0;
 
     public bool Initialize(AbstractAttackBehaviour attackBehaviour, float fireRate = 0.1f, int magSize = 1)
     {
         if (_initialized) return false;
         _initialized = true;
-        
         _attackBehaviour = attackBehaviour;
         _fireRate = fireRate; 
         _magazineSize = magSize;

--- a/Assets/Scripts/Weapons/Weapon.cs
+++ b/Assets/Scripts/Weapons/Weapon.cs
@@ -17,7 +17,7 @@ public class Weapon : MonoBehaviour
     public float _fireRate; // shots per second
     public int _magazineSize;
     int _currentMagazine;
-    public double lastShot = 0;
+    double lastShot = 0;
 
     public bool Initialize(AbstractAttackBehaviour attackBehaviour, float fireRate = 0.1f, int magSize = 1)
     {


### PR DESCRIPTION
Changes
* PowerUp framework implemented
* Stat PowerUps implemented except for Reload Speed

Summary
powerups are sorted into classes, statpowerups are applied directly and are not stored. the other classes will be stored in an array in powerupmanager that we will look through when we need to apply the effects of the powerup.

to trigger the entire powerup framework, call presentPowerUp() from PowerUpManager.

closes #12 and #7 , will be closing previous PR #37 