### PR TITLE
Implement Healing Varient of Turret

### DIFF
--- a/Assets/Scripts/Enemy/EnemyFactory.cs
+++ b/Assets/Scripts/Enemy/EnemyFactory.cs
@@ -103,13 +103,5 @@ public class EnemyFactory
 
         // Define enemyInfo for each type.
         _enemyInfo.Add(EnemyType.TURRET, new EnemyInfo(_defaultFunc, Globals.DirectTargeting, _defaultMove, bulletBehaviour, fireRate));
-
-        // Set up the dictionary with methods.
-        _enemyPostSetups.Add(EnemyVariantType.NONE, CreateTurret);
-    }
-
-    void CreateTurret(EnemyBehaviour eb)
-    {
-
     }
 }

--- a/Assets/Scripts/Enemy/EnemyFactory.cs
+++ b/Assets/Scripts/Enemy/EnemyFactory.cs
@@ -51,10 +51,10 @@ public class EnemyFactory
     public EnemyFactory()
     {
         AddTurretToRoster();
-        AddHealerVarientToRoster();
+        AddHealerVariantToRoster();
     }
 
-    public GameObject CreateEnemy(Vector3 position, EnemyType enemyType, EnemyVariantType varientType = EnemyVariantType.NONE)
+    public GameObject CreateEnemy(Vector3 position, EnemyType enemyType, EnemyVariantType variantType = EnemyVariantType.NONE)
     {
         // Janky, find a better place for this. Unsure when the Player object is available.
         if (_defaultTarget == null) _defaultTarget = GameObject.FindGameObjectWithTag("Player");
@@ -79,18 +79,18 @@ public class EnemyFactory
             _defaultTarget,
             enemyInfo,
             enemyWeapon);
-        if (varientType != EnemyVariantType.NONE && _enemyPostSetups.ContainsKey(varientType)) _enemyPostSetups[varientType](eb);
+        if (variantType != EnemyVariantType.NONE && _enemyPostSetups.ContainsKey(variantType)) _enemyPostSetups[variantType](eb);
 
         return newEnemyObject;
     }
 
-    void AddHealerVarientToRoster()
+    void AddHealerVariantToRoster()
     {
         // Set up the dictionary with methods.
-        _enemyPostSetups.Add(EnemyVariantType.HEALER, CreateHealerVarient);
+        _enemyPostSetups.Add(EnemyVariantType.HEALER, CreateHealerVariant);
     }
 
-    void CreateHealerVarient(EnemyBehaviour eb)
+    void CreateHealerVariant(EnemyBehaviour eb)
     {
         AbstractAttackBehaviour enemyAttackBehaviour = eb.GetComponent<Weapon>()._attackBehaviour;
         if (enemyAttackBehaviour._damage > 0) enemyAttackBehaviour._damage *= -1; 

--- a/Assets/Scripts/Enemy/EnemyFactory.cs
+++ b/Assets/Scripts/Enemy/EnemyFactory.cs
@@ -31,7 +31,7 @@ public class EnemyFactory
 {
 
     // Additional setup for an enemy.
-    private static Dictionary<EnemyVarientType, Action<EnemyBehaviour>> _enemyPostSetups = new Dictionary<EnemyVarientType, Action<EnemyBehaviour>>();
+    private static Dictionary<EnemyVariantType, Action<EnemyBehaviour>> _enemyPostSetups = new Dictionary<EnemyVariantType, Action<EnemyBehaviour>>();
     private static Dictionary<EnemyType, EnemyInfo> _enemyInfo = new Dictionary<EnemyType, EnemyInfo>();
     private static Func<Transform, Transform, Vector3> _defaultFunc = (Transform t1, Transform t2) => new Vector3(0, 0, 0);
     private static Action<Transform, Vector3> _defaultMove = (Transform t, Vector3 v) => t.position += v * Time.deltaTime;
@@ -54,7 +54,7 @@ public class EnemyFactory
         AddHealerVarientToRoster();
     }
 
-    public GameObject CreateEnemy(Vector3 position, EnemyType enemyType, EnemyVarientType varientType = EnemyVarientType.NONE)
+    public GameObject CreateEnemy(Vector3 position, EnemyType enemyType, EnemyVariantType varientType = EnemyVariantType.NONE)
     {
         // Janky, find a better place for this. Unsure when the Player object is available.
         if (_defaultTarget == null) _defaultTarget = GameObject.FindGameObjectWithTag("Player");
@@ -79,7 +79,7 @@ public class EnemyFactory
             _defaultTarget,
             enemyInfo,
             enemyWeapon);
-        if (varientType != EnemyVarientType.NONE && _enemyPostSetups.ContainsKey(varientType)) _enemyPostSetups[varientType](eb);
+        if (varientType != EnemyVariantType.NONE && _enemyPostSetups.ContainsKey(varientType)) _enemyPostSetups[varientType](eb);
 
         return newEnemyObject;
     }
@@ -87,7 +87,7 @@ public class EnemyFactory
     void AddHealerVarientToRoster()
     {
         // Set up the dictionary with methods.
-        _enemyPostSetups.Add(EnemyVarientType.HEALER, CreateHealerVarient);
+        _enemyPostSetups.Add(EnemyVariantType.HEALER, CreateHealerVarient);
     }
 
     void CreateHealerVarient(EnemyBehaviour eb)
@@ -105,7 +105,7 @@ public class EnemyFactory
         _enemyInfo.Add(EnemyType.TURRET, new EnemyInfo(_defaultFunc, Globals.DirectTargeting, _defaultMove, bulletBehaviour, fireRate));
 
         // Set up the dictionary with methods.
-        _enemyPostSetups.Add(EnemyVarientType.NONE, CreateTurret);
+        _enemyPostSetups.Add(EnemyVariantType.NONE, CreateTurret);
     }
 
     void CreateTurret(EnemyBehaviour eb)

--- a/Assets/Scripts/Enemy/EnemyFactory.cs
+++ b/Assets/Scripts/Enemy/EnemyFactory.cs
@@ -51,7 +51,7 @@ public class EnemyFactory
     public EnemyFactory()
     {
         AddTurretToRoster();
-        AddTurret_HealerVarient_ToRoster();
+        AddHealerVarientToRoster();
     }
 
     public GameObject CreateEnemy(Vector3 position, EnemyType enemyType, EnemyVarientType varientType = EnemyVarientType.NONE)
@@ -84,18 +84,18 @@ public class EnemyFactory
         return newEnemyObject;
     }
 
-    void AddTurret_HealerVarient_ToRoster()
+    void AddHealerVarientToRoster()
     {
         // Set up the dictionary with methods.
-        _enemyPostSetups.Add(EnemyVarientType.HEALER, CreateTurret_HealerVarient);
+        _enemyPostSetups.Add(EnemyVarientType.HEALER, CreateHealerVarient);
     }
 
-    void CreateTurret_HealerVarient(EnemyBehaviour eb)
+    void CreateHealerVarient(EnemyBehaviour eb)
     {
         AbstractAttackBehaviour enemyAttackBehaviour = eb.GetComponent<Weapon>()._attackBehaviour;
-        enemyAttackBehaviour._damage *= -1; 
+        if (enemyAttackBehaviour._damage > 0) enemyAttackBehaviour._damage *= -1; 
     }
-
+    
     void AddTurretToRoster()
     {
         BulletAttackBehaviour bulletBehaviour = new BulletAttackBehaviour(EntityType.ENEMY);

--- a/Assets/Scripts/EnemySpawn.cs
+++ b/Assets/Scripts/EnemySpawn.cs
@@ -124,7 +124,7 @@ public class EnemySpawn : MonoBehaviour
         Vector3 targetSpawn;
         if (RandomPoint(platformRadius, out targetSpawn)) {
             Debug.DrawRay(targetSpawn, Vector3.up, Color.blue, 1.0f);
-            EnemyFactory.Instance.CreateEnemy(EnemyType.TURRET, targetSpawn);
+            EnemyFactory.Instance.CreateEnemy(targetSpawn, EnemyType.TURRET);
         }
     }
 

--- a/Assets/Scripts/EnemySpawn.cs
+++ b/Assets/Scripts/EnemySpawn.cs
@@ -124,7 +124,7 @@ public class EnemySpawn : MonoBehaviour
         Vector3 targetSpawn;
         if (RandomPoint(platformRadius, out targetSpawn)) {
             Debug.DrawRay(targetSpawn, Vector3.up, Color.blue, 1.0f);
-            EnemyFactory.Instance.CreateEnemy(targetSpawn, EnemyType.TURRET, EnemyVarientType.HEALER);
+            EnemyFactory.Instance.CreateEnemy(targetSpawn, EnemyType.TURRET);
         }
     }
 

--- a/Assets/Scripts/EnemySpawn.cs
+++ b/Assets/Scripts/EnemySpawn.cs
@@ -124,7 +124,7 @@ public class EnemySpawn : MonoBehaviour
         Vector3 targetSpawn;
         if (RandomPoint(platformRadius, out targetSpawn)) {
             Debug.DrawRay(targetSpawn, Vector3.up, Color.blue, 1.0f);
-            EnemyFactory.Instance.CreateEnemy(targetSpawn, EnemyType.TURRET);
+            EnemyFactory.Instance.CreateEnemy(targetSpawn, EnemyType.TURRET, EnemyVarientType.HEALER);
         }
     }
 

--- a/Assets/Scripts/Globals.cs
+++ b/Assets/Scripts/Globals.cs
@@ -4,48 +4,51 @@ using UnityEngine;
 
 public static class Globals
 {
-	public static Dictionary<PowerUpType, StatPowerUp> StatPowerUpDictionary = new Dictionary<PowerUpType, StatPowerUp>
-	{{PowerUpType.DAMAGE, new StatPowerUp(5f)},
-	{PowerUpType.FIRERATE, new StatPowerUp(-0.04f)},
-	{PowerUpType.RELOADSPD, new StatPowerUp(1f)},
-	{PowerUpType.CLIPSIZE, new StatPowerUp(2f)},
-	{PowerUpType.ADRENALIN, new StatPowerUp(0.15f)}
-	};
+    public static Dictionary<PowerUpType, StatPowerUp> StatPowerUpDictionary = new Dictionary<PowerUpType, StatPowerUp>
+    {{PowerUpType.DAMAGE, new StatPowerUp(5f)},
+    {PowerUpType.FIRERATE, new StatPowerUp(-0.04f)},
+    {PowerUpType.RELOADSPD, new StatPowerUp(1f)},
+    {PowerUpType.CLIPSIZE, new StatPowerUp(2f)},
+    {PowerUpType.ADRENALIN, new StatPowerUp(0.15f)}
+    };
 
-	public static Vector3 DirectTargeting(Transform from, Transform to) {
-		Vector3 direction = (to.position - from.position).normalized;
-		return direction;
-	}
+    public static Vector3 DirectTargeting(Transform from, Transform to)
+    {
+        Vector3 direction = (to.position - from.position).normalized;
+        return direction;
+    }
 
-	public static Dictionary<EnemyType, string> enemyPrefabNames = new Dictionary<EnemyType, string>()
-	{
-		{ EnemyType.TURRET, "Turret" },
+    public static Dictionary<EnemyType, string> enemyPrefabNames = new Dictionary<EnemyType, string>()
+    {
+        { EnemyType.TURRET, "Turret" },
         { EnemyType.HEALER, "Healer" }
-	};
+    };
 }
 
 public enum EnemyType
 {
-	TURRET,
+    TURRET,
     HEALER
 }
 
-public enum EnemyVarientType
+public enum EnemyVariantType
 {
     NONE,
     HEALER
 }
 
-public enum EntityType {
-	PLAYER,
-	ENEMY
+public enum EntityType
+{
+    PLAYER,
+    ENEMY
 }
 
-public enum PowerUpType{
-	NONE,
-	DAMAGE,
-	FIRERATE,
-	RELOADSPD,
-	CLIPSIZE,
-	ADRENALIN
+public enum PowerUpType
+{
+    NONE,
+    DAMAGE,
+    FIRERATE,
+    RELOADSPD,
+    CLIPSIZE,
+    ADRENALIN
 }

--- a/Assets/Scripts/Globals.cs
+++ b/Assets/Scripts/Globals.cs
@@ -19,13 +19,21 @@ public static class Globals
 
 	public static Dictionary<EnemyType, string> enemyPrefabNames = new Dictionary<EnemyType, string>()
 	{
-		{ EnemyType.TURRET, "Turret" }
+		{ EnemyType.TURRET, "Turret" },
+        { EnemyType.HEALER, "Healer" }
 	};
 }
 
 public enum EnemyType
 {
-	TURRET
+	TURRET,
+    HEALER
+}
+
+public enum EnemyVarientType
+{
+    NONE,
+    HEALER
 }
 
 public enum EntityType {

--- a/Assets/Scripts/Stats.cs
+++ b/Assets/Scripts/Stats.cs
@@ -29,7 +29,7 @@ public class Stats : MonoBehaviour
 
     void setHealth(float health)
     {
-        currentHealth = Mathf.Clamp(health, 0, maxHealth);
+        currentHealth = health;
         if (owner == EntityType.PLAYER)
         {
             UIManager.Health = currentHealth;


### PR DESCRIPTION
## Changes
- `EnemyPostSetups` contains varient-specific setups
- `CreateEnemy` takes in VarientType (default to NONE)
- Remove Clamp restriction to allow overhealing (although not being reflected in UI) @ikeia would appreciate some help on this.
- Healing Varient can theoretically be added to any kind of enemies that we have, since it's more of a property. 

Closes #9 