### PR TITLE
Predictive targeting

### DIFF
--- a/Assets/Scripts/Enemy/EnemyBehaviour.cs
+++ b/Assets/Scripts/Enemy/EnemyBehaviour.cs
@@ -20,7 +20,7 @@ public class EnemyBehaviour : MonoBehaviour
     // Method to pathfind from Transform to Transform, returns Vector3, the direction to move in next.
     private Action<GameObject, Vector3> NavAgentMove;
     // Method to determine aiming direction from Transform to Transform, returns Vector3, the direction to fire in.
-    private Func<Transform, Transform, Vector3> GetAimDirection;
+    public Func<Transform, Transform, Vector3> GetAimDirection;
     
     IEnumerator Cooldown()
     {

--- a/Assets/Scripts/Enemy/EnemyFactory.cs
+++ b/Assets/Scripts/Enemy/EnemyFactory.cs
@@ -109,7 +109,7 @@ public class EnemyFactory
         _enemyPostSetups.Add(EnemyVariantType.SET, CreateSetVariant);
     }
 
-    void CreateSetVariant(EnemyBehaviour eb)
+    void CreateSetVariant(EnemyBehaviour eb, EnemyType et)
     {
         Weapon weapon = eb.GetComponent<Weapon>();
         weapon.firingMods.Add(new SetFiringPowerUp());

--- a/Assets/Scripts/Enemy/EnemySpawn.cs
+++ b/Assets/Scripts/Enemy/EnemySpawn.cs
@@ -193,6 +193,11 @@ public class EnemySpawn : MonoBehaviour
             variant = EnemyVariantType.NONE;
             enemyType = enemy;
         }
+        // 50% to be predictive if turret or ranged.
+        if ((enemyType == EnemyType.TURRET || enemyType == EnemyType.RANGED) && Random.Range(0, 2) == 0)
+        {
+            variant = EnemyVariantType.PREDICTIVE;
+        }
         if (RandomPoint(platformRadius, out targetSpawn))
         {
             Debug.DrawRay(targetSpawn, Vector3.up, Color.blue, 1.0f);

--- a/Assets/Scripts/Globals.cs
+++ b/Assets/Scripts/Globals.cs
@@ -95,6 +95,11 @@ public static class Globals
         { EnemyType.GRENADIER, "Grenadier"},
         { EnemyType.RANGED, "Ranged"}
     };
+
+	public static Dictionary<EnemyType, float> enemyBulletSpeeds = new Dictionary<EnemyType, float>() {
+		{ EnemyType.TURRET, 20f },
+		{ EnemyType.RANGED, 20f }
+	};
 }
 
 public enum EnemyType
@@ -107,7 +112,8 @@ public enum EnemyType
 public enum EnemyVariantType
 {
     NONE,
-    HEALER
+    HEALER,
+	PREDICTIVE
 }
 
 public enum EntityType

--- a/Assets/Scripts/Globals.cs
+++ b/Assets/Scripts/Globals.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -58,6 +59,31 @@ public static class Globals
         Vector3 direction = (to.position - from.position).normalized;
         return direction;
     }
+
+	public static Func<Transform, Transform, Vector3> CreatePredictiveTargeting(Transform target, float bSpeed) {
+		float bulletSpeed = bSpeed;
+		Vector3 prevPosition = new Vector3(target.position.x, target.position.y, target.position.z);
+		float prevTime = Time.time;
+		Func<Transform, Transform, Vector3> predictive = delegate(Transform from, Transform to) {
+			float modifiedBulletSpeed = bulletSpeed*SpeedManager.bulletSpeedScaling;
+			Vector3 enemyDir = (to.position - prevPosition).normalized;
+			Vector3 plane = MathModule.determinePlaneNormal(from.position, to.position, to.position + enemyDir);
+			float now = Time.time;
+			float enemySpeed = (to.position - prevPosition).magnitude/(now - prevTime);
+			// Use law of sines
+			float angleBeta = Vector3.Angle(from.position - to.position, enemyDir);
+			// Angles towards or away cause the plane defined to not have a major y-component... in these cases, just shoot at them
+			if (angleBeta >= 170f || angleBeta <= 10f) return (to.position - from.position).normalized;
+			float angleAlpha = Mathf.Abs(Mathf.Rad2Deg*Mathf.Asin(enemySpeed*Mathf.Sin(angleBeta*Mathf.Deg2Rad)/modifiedBulletSpeed));
+			Vector3 firingDirection = Quaternion.AngleAxis(angleAlpha, plane) * (to.position - from.position);
+			prevPosition.x = to.position.x;
+			prevPosition.y = to.position.y;
+			prevPosition.z = to.position.z;
+			prevTime = now;
+			return firingDirection.normalized;
+		};
+		return predictive;
+	}
 
 	public static Vector3 GrenadierTargeting(Transform from, Transform to) {
 		return to.position;

--- a/Assets/Scripts/Weapons/BulletAttackBehaviour.cs
+++ b/Assets/Scripts/Weapons/BulletAttackBehaviour.cs
@@ -11,7 +11,7 @@ public class BulletAttackBehaviour : AbstractAttackBehaviour
     public Dictionary<string, int> _hitTypeModifiers;
     public Dictionary<string, float> _hitStatsModifiers;
 
-    public BulletAttackBehaviour(EntityType owner, float damage = 10f, float bulletSpeed = 10f) 
+    public BulletAttackBehaviour(EntityType owner, float damage = 10f, float bulletSpeed = 20f) 
         : base(owner, damage)
     {
         _bulletSpeed = bulletSpeed;


### PR DESCRIPTION
Ranged and turret enemies will now spawn with predictive targeting 50% of the time.
Bullet speeds for ranged and turret is defined in a dictionary in Globals. Turret bullet speed has been bumped from 10 -> 20 so predictive targeting math doesn't go undefined.
![image](https://user-images.githubusercontent.com/23041363/157540769-20c4b546-fa77-48d7-a508-3a005854a2a5.png)

closes #84 