### PR TITLE
Speed tweaks

### DIFF
--- a/Assets/Scripts/SpeedManager.cs
+++ b/Assets/Scripts/SpeedManager.cs
@@ -11,8 +11,9 @@ public class SpeedManager : MonoBehaviour
     public static float adrenalinModifier = 0f;
     public static float enemyMovementScaling;
     public static double realTime = 0;
-    
-    void Start() {
+
+    void Start()
+    {
         playerMovementScaling = coreSpeed; //TODO: determine player movement ratio based on speed
         bulletSpeedScaling = coreSpeed; //TODO: determine bullet speed ratio based on speed
         enemySpawnScaling = coreSpeed; //TODO: determine spawn rate based on speed
@@ -25,14 +26,16 @@ public class SpeedManager : MonoBehaviour
         updateGameObjectSpeed();
     }
 
-    static void updateGameObjectSpeed(){
+    static void updateGameObjectSpeed()
+    {
         playerMovementScaling = coreSpeed + adrenalin();
         bulletSpeedScaling = coreSpeed;
         enemySpawnScaling = 0.2f / coreSpeed;
         enemyMovementScaling = coreSpeed;
     }
 
-    static float adrenalin(){
+    static float adrenalin()
+    {
         // experimental function for adjusting the game speed
         // the lower hp we are, the more adrenalin does
         //

--- a/Assets/Scripts/SpeedManager.cs
+++ b/Assets/Scripts/SpeedManager.cs
@@ -21,7 +21,7 @@ public class SpeedManager : MonoBehaviour
     public static void updateSpeeds(float healthRatio)
     {
         coreSpeed = 0.2f + healthRatio * 0.8f;
-        if (healthRatio > 1) coreSpeed = (healthRatio - 1f) * 6f - 1f;
+        if (healthRatio > 1) coreSpeed = 4 * (healthRatio - 1) * (healthRatio - 1) + 1;
         updateGameObjectSpeed();
     }
 

--- a/Assets/Scripts/SpeedManager.cs
+++ b/Assets/Scripts/SpeedManager.cs
@@ -21,6 +21,7 @@ public class SpeedManager : MonoBehaviour
     public static void updateSpeeds(float healthRatio)
     {
         coreSpeed = 0.2f + healthRatio * 0.8f;
+        if (healthRatio > 1) coreSpeed = (healthRatio - 1f) * 6f - 1f;
         updateGameObjectSpeed();
     }
 

--- a/Assets/Scripts/SpeedManager.cs
+++ b/Assets/Scripts/SpeedManager.cs
@@ -18,8 +18,9 @@ public class SpeedManager : MonoBehaviour
         enemySpawnScaling = coreSpeed; //TODO: determine spawn rate based on speed
         enemyMovementScaling = coreSpeed;
     }
-    public static void updateSpeeds(float healthRatio) {
-        coreSpeed = healthRatio;
+    public static void updateSpeeds(float healthRatio)
+    {
+        coreSpeed = 0.2f + healthRatio * 0.8f;
         updateGameObjectSpeed();
     }
 

--- a/Assets/Scripts/Weapons/Weapon.cs
+++ b/Assets/Scripts/Weapons/Weapon.cs
@@ -7,7 +7,7 @@ using DG.Tweening;
 public class Weapon : MonoBehaviour
 {
     private bool _initialized = false;
-	public List<AbstractFiringPowerUp> firingMods = new List<AbstractFiringPowerUp>();
+    public List<AbstractFiringPowerUp> firingMods = new List<AbstractFiringPowerUp>();
 
     public AbstractAttackBehaviour _attackBehaviour;
     public float _fireRate; // shots per second
@@ -41,24 +41,25 @@ public class Weapon : MonoBehaviour
         if (SpeedManager.realTime - lastShot > _fireRate && !_reloading)
         {
             if (_currentMagazine > 0)
-            {                
+            {
                 List<(Vector3, float)> attackDirections = new List<(Vector3, float)>();
                 attackDirections.Add((direction, 0f));
-                      
+
                 // apply each powerup in poweruplist, creating a growing list of firing directions
                 // assumptions: firingMods is sorted (handled in PowerUpManager)
-				for (int i = 0; i < firingMods.Count; i++)
+                for (int i = 0; i < firingMods.Count; i++)
                 {
                     attackDirections = firingMods[i].applyPowerUp(attackDirections);
                 }
 
                 // for each direction, initiate an attack
-				for (int j = 0; j < attackDirections.Count; j++)
+                for (int j = 0; j < attackDirections.Count; j++)
                 {
                     StartCoroutine(ShootAfterDelay(position, attackDirections[j].Item1, attackDirections[j].Item2));
                 }
                 _currentMagazine -= 1; // Comment out for infinite ammo
-                if (entityType == EntityType.PLAYER) {
+                if (entityType == EntityType.PLAYER)
+                {
                     AudioManager.PlayFireAudio();
                 }
                 lastShot = SpeedManager.realTime;
@@ -77,7 +78,8 @@ public class Weapon : MonoBehaviour
     public void Reload()
     {
         _reloading = true;
-        if (_attackBehaviour.Owner.ToString() == "PLAYER") {
+        if (_attackBehaviour.Owner.ToString() == "PLAYER")
+        {
             UIManager.Reloading = true;
             AudioManager.PlayReloadAudio();
         }

--- a/Assets/Scripts/Weapons/Weapon.cs
+++ b/Assets/Scripts/Weapons/Weapon.cs
@@ -38,7 +38,7 @@ public class Weapon : MonoBehaviour
     public bool Attack(Vector3 position, Vector3 direction, EntityType entityType)
     {
 
-        if (Time.time - lastShot > _fireRate && !_reloading)
+        if (SpeedManager.realTime - lastShot > _fireRate && !_reloading)
         {
             if (_currentMagazine > 0)
             {                
@@ -61,7 +61,7 @@ public class Weapon : MonoBehaviour
                 if (entityType == EntityType.PLAYER) {
                     AudioManager.PlayFireAudio();
                 }
-                lastShot = Time.time;
+                lastShot = SpeedManager.realTime;
                 return true;
             }
             else


### PR DESCRIPTION
Health now scales speed from 20% to 100% rather than 0% to 100%, resulting in a maximal 5x slowdown.
When overhealing, 100%+ hp scales quadratically according to 4x^2 + 1 = speed, where x = healthRatio - 1.
This gets us 2x speed at 150% hp and 5x speed at 200% hp, mirroring a 0.5x speed at 50% hp and 0.2x speed at 0% hp. 

Fire rate now uses scaled time.
closes #119 