### PR TITLE
Object pooling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 root = true
 
 [*.{cs,vb}]
-indent_style = space
+indent_style = tab
 indent_size = 4

--- a/Assets/Scripts/Enemy/EnemyBehaviour.cs
+++ b/Assets/Scripts/Enemy/EnemyBehaviour.cs
@@ -8,81 +8,82 @@ using UnityEngine;
  */
 public class EnemyBehaviour : MonoBehaviour
 {
-    private bool _initialized = false;
+	private bool _initialized = false;
 	public EnemyType enemyType;
-    // Transform of the enemy's target.
-    private Transform _targetTransform;
-    private Quaternion _lookRotation;
-    private Vector3 _direction;
-    private Weapon _weapon;
+	// Transform of the enemy's target.
+	private Transform _targetTransform;
+	private Quaternion _lookRotation;
+	private Vector3 _direction;
+	private Weapon _weapon;
 
-    // Method to pathfind from Transform to Transform, returns Vector3, the direction to move in next.
-    private Action<GameObject, Vector3> NavAgentMove;
-    // Method to determine aiming direction from Transform to Transform, returns Vector3, the direction to fire in.
-    public Func<Transform, Transform, Vector3> GetAimDirection;
+	// Method to pathfind from Transform to Transform, returns Vector3, the direction to move in next.
+	private Action<GameObject, Vector3> NavAgentMove;
+	// Method to determine aiming direction from Transform to Transform, returns Vector3, the direction to fire in.
+	public Func<Transform, Transform, Vector3> GetAimDirection;
 
-    public static EnemyBehaviour AddToGameObject(
-        GameObject gameObject, 
-        GameObject target, 
-        EnemyInfo info,
-        Weapon weapon)
-    {
-        EnemyBehaviour eb = gameObject.AddComponent<EnemyBehaviour>();
-        eb.Initialize(target, info, weapon);
+	public static EnemyBehaviour AddToGameObject(
+		GameObject gameObject,
+		GameObject target,
+		EnemyInfo info,
+		Weapon weapon)
+	{
+		EnemyBehaviour eb = gameObject.AddComponent<EnemyBehaviour>();
+		eb.Initialize(target, info, weapon);
 
-        return eb;
-    }
+		return eb;
+	}
 
-    // Initialize must be run for the Update loop to run.
-    // This is because the mechanisms (Pathfind, Aim, etc.) aren't set until Initialize is called.
-    public bool Initialize(GameObject target, 
-        EnemyInfo info,
-        Weapon weapon)
-    {
-        if (_initialized) return false;
-        _initialized = true;
+	// Initialize must be run for the Update loop to run.
+	// This is because the mechanisms (Pathfind, Aim, etc.) aren't set until Initialize is called.
+	public bool Initialize(GameObject target,
+		EnemyInfo info,
+		Weapon weapon)
+	{
+		if (_initialized) return false;
+		_initialized = true;
 
 		enemyType = info.enemyType;
-        _weapon = weapon;
-        _targetTransform = target.GetComponent<Transform>();
-        NavAgentMove = info.navAgentMove;
-        GetAimDirection = info.aim;
-        info.navAgentSetup(new Vector3(0, 0, 0));
-        
-        return true;
-    }
-    
-	public static void Destroy(GameObject enemy) {
+		_weapon = weapon;
+		_targetTransform = target.GetComponent<Transform>();
+		NavAgentMove = info.navAgentMove;
+		GetAimDirection = info.aim;
+		info.navAgentSetup(new Vector3(0, 0, 0));
+
+		return true;
+	}
+
+	public static void Destroy(GameObject enemy)
+	{
 		EnemyBehaviour eb = enemy.GetComponent<EnemyBehaviour>();
 		EnemyType type = eb.enemyType;
 		Destroy(eb);
 		ObjectPool.Destroy(Globals.enemyPrefabNames[type], enemy);
 	}
 
-    // Update is called once per frame
-    void Update()
-    {
-        if (!_initialized) return;
+	// Update is called once per frame
+	void Update()
+	{
+		if (!_initialized) return;
 
-        Animation anim = gameObject.transform.GetChild(0).GetComponent<Animation>();
-        // Look. Determine look direction.
-        _direction = (_targetTransform.position - transform.position).normalized;
-        _direction.y = 0;
-        _lookRotation = Quaternion.LookRotation(_direction);
-        transform.rotation = _lookRotation;
-        
-        NavAgentMove(this.gameObject, _targetTransform.position);
-        
-        // Aim. Determine firing direction.
-        Vector3 aimDirection = GetAimDirection(transform, _targetTransform);
+		Animation anim = gameObject.transform.GetChild(0).GetComponent<Animation>();
+		// Look. Determine look direction.
+		_direction = (_targetTransform.position - transform.position).normalized;
+		_direction.y = 0;
+		_lookRotation = Quaternion.LookRotation(_direction);
+		transform.rotation = _lookRotation;
 
-        // TODO: spawn bullet outside of model
-        if (_weapon.Attack(transform.position, aimDirection, EntityType.ENEMY))
-        {
-            foreach (AnimationState state in anim)
-            {
-                if (state.name == "shoot") anim.Play("shoot");
-            }
-        }
-    }
+		NavAgentMove(this.gameObject, _targetTransform.position);
+
+		// Aim. Determine firing direction.
+		Vector3 aimDirection = GetAimDirection(transform, _targetTransform);
+
+		// TODO: spawn bullet outside of model
+		if (_weapon.Attack(transform.position, aimDirection, EntityType.ENEMY))
+		{
+			foreach (AnimationState state in anim)
+			{
+				if (state.name == "shoot") anim.Play("shoot");
+			}
+		}
+	}
 }

--- a/Assets/Scripts/Enemy/EnemyBehaviour.cs
+++ b/Assets/Scripts/Enemy/EnemyBehaviour.cs
@@ -9,24 +9,17 @@ using UnityEngine;
 public class EnemyBehaviour : MonoBehaviour
 {
     private bool _initialized = false;
+	public EnemyType enemyType;
     // Transform of the enemy's target.
     private Transform _targetTransform;
     private Quaternion _lookRotation;
     private Vector3 _direction;
-    private bool _cooldown = false;
-    private float _cooldownDelay = 1f;
     private Weapon _weapon;
 
     // Method to pathfind from Transform to Transform, returns Vector3, the direction to move in next.
     private Action<GameObject, Vector3> NavAgentMove;
     // Method to determine aiming direction from Transform to Transform, returns Vector3, the direction to fire in.
     public Func<Transform, Transform, Vector3> GetAimDirection;
-    
-    IEnumerator Cooldown()
-    {
-        yield return new WaitForSeconds(_cooldownDelay);
-        _cooldown = false;
-    }
 
     public static EnemyBehaviour AddToGameObject(
         GameObject gameObject, 
@@ -49,6 +42,7 @@ public class EnemyBehaviour : MonoBehaviour
         if (_initialized) return false;
         _initialized = true;
 
+		enemyType = info.enemyType;
         _weapon = weapon;
         _targetTransform = target.GetComponent<Transform>();
         NavAgentMove = info.navAgentMove;
@@ -58,8 +52,12 @@ public class EnemyBehaviour : MonoBehaviour
         return true;
     }
     
-    // Start is called before the first frame update
-    void Start() {}
+	public static void Destroy(GameObject enemy) {
+		EnemyBehaviour eb = enemy.GetComponent<EnemyBehaviour>();
+		EnemyType type = eb.enemyType;
+		Destroy(eb);
+		ObjectPool.Destroy(Globals.enemyPrefabNames[type], enemy);
+	}
 
     // Update is called once per frame
     void Update()

--- a/Assets/Scripts/Enemy/EnemyFactory.cs
+++ b/Assets/Scripts/Enemy/EnemyFactory.cs
@@ -6,15 +6,17 @@ using UnityEngine;
 // Define EnemyInfo for convenience.
 public struct EnemyInfo
 {
+    public EnemyType enemyType;
     public Action<GameObject, Vector3> navAgentMove;
     public Func<Transform, Transform, Vector3> aim;
     public Action<Vector3> navAgentSetup;
     public AbstractAttackBehaviour attackBehaviour;
     public float fireRate;
 
-    public EnemyInfo(Action<GameObject, Vector3> navAgentMoveFunc, Func<Transform, Transform, Vector3> aimFunc,
+    public EnemyInfo(EnemyType type, Action<GameObject, Vector3> navAgentMoveFunc, Func<Transform, Transform, Vector3> aimFunc,
         Action<Vector3> navAgentSetupFunc, AbstractAttackBehaviour attackBehaviour, float fireRate)
     {
+        enemyType = type;
         navAgentMove = navAgentMoveFunc;
         aim = aimFunc;
         navAgentSetup = navAgentSetupFunc;
@@ -50,8 +52,8 @@ public class EnemyFactory
     {
         // Define enemyInfo for each type.
         AddTurretToRoster();
-        _enemyInfo.Add(EnemyType.GRENADIER, new EnemyInfo(EnemyMovements.GrenadierMovement, Globals.GrenadierTargeting, EnemyMovements.GrenadierSetup, new ArtilleryAttackBehaviour(EntityType.ENEMY, 5f), 3f));
-        _enemyInfo.Add(EnemyType.RANGED, new EnemyInfo(EnemyMovements.RangedMovement, Globals.DirectTargeting, EnemyMovements.RangedSetup, new BulletAttackBehaviour(EntityType.ENEMY, 5f, Globals.enemyBulletSpeeds[EnemyType.RANGED]), 1f));
+        _enemyInfo.Add(EnemyType.GRENADIER, new EnemyInfo(EnemyType.GRENADIER, EnemyMovements.GrenadierMovement, Globals.GrenadierTargeting, EnemyMovements.GrenadierSetup, new ArtilleryAttackBehaviour(EntityType.ENEMY, 5f), 3f));
+        _enemyInfo.Add(EnemyType.RANGED, new EnemyInfo(EnemyType.RANGED, EnemyMovements.RangedMovement, Globals.DirectTargeting, EnemyMovements.RangedSetup, new BulletAttackBehaviour(EntityType.ENEMY, 5f, Globals.enemyBulletSpeeds[EnemyType.RANGED]), 1f));
         AddHealerVariantToRoster();
         _enemyPostSetups.Add(EnemyVariantType.PREDICTIVE, CreatePredictiveVariant);
     }
@@ -64,8 +66,8 @@ public class EnemyFactory
         if (!Globals.enemyPrefabNames.ContainsKey(enemyType)) return null;
 
         string enemyName = Globals.enemyPrefabNames[enemyType];
-        
-        GameObject newEnemyObject = GameObject.Instantiate(Resources.Load(enemyName)) as GameObject;
+
+        GameObject newEnemyObject = ObjectPool.Create(enemyName);
         Transform enemyTransform = newEnemyObject.GetComponent<Transform>();
         CompassUI.addEnemy(enemyTransform);
 
@@ -105,7 +107,7 @@ public class EnemyFactory
         float fireRate = 5f;
 
         // Define enemyInfo for each type.
-        _enemyInfo.Add(EnemyType.TURRET, new EnemyInfo(EnemyMovements.TurretMovement, Globals.DirectTargeting, EnemyMovements.TurretSetup, bulletBehaviour, fireRate));
+        _enemyInfo.Add(EnemyType.TURRET, new EnemyInfo(EnemyType.TURRET, EnemyMovements.TurretMovement, Globals.DirectTargeting, EnemyMovements.TurretSetup, bulletBehaviour, fireRate));
         
         _enemyPostSetups.Add(EnemyVariantType.SET, CreateSetVariant);
     }

--- a/Assets/Scripts/HealingPill.cs
+++ b/Assets/Scripts/HealingPill.cs
@@ -4,41 +4,42 @@ using UnityEngine;
 
 public class HealingPill : MonoBehaviour
 {
-    private static List<GameObject> currentPills = new List<GameObject>();
+	private static List<GameObject> currentPills = new List<GameObject>();
 
-    public static GameObject SpawnPill(Vector3 position)
-    {
-        GameObject newHealingPill = ObjectPool.Create("HealingPill");
-        Transform pillTransform = newHealingPill.GetComponent<Transform>();
-        pillTransform.position = position;
-        currentPills.Add(newHealingPill);
-        return newHealingPill;
-    }
+	public static GameObject SpawnPill(Vector3 position)
+	{
+		GameObject newHealingPill = ObjectPool.Create("HealingPill");
+		Transform pillTransform = newHealingPill.GetComponent<Transform>();
+		pillTransform.position = position;
+		currentPills.Add(newHealingPill);
+		return newHealingPill;
+	}
 
-    public static void DespawnPills()
-    {
-        foreach (GameObject pill in currentPills)
-        {
-            ObjectPool.Destroy("HealingPill", pill);
-        }
-        currentPills.Clear();
-    }
-    
-    void Update(){
-        gameObject.transform.rotation *= Quaternion.AngleAxis(-3, Vector3.forward);
-    }
-    
-    public void OnTriggerEnter(Collider other)
-    {
-        if(other.tag == "Player")
-        {
-            Stats statComponent = other.gameObject.GetComponent<Stats>();
-            statComponent.currentHealth += 15;
-            if(statComponent.currentHealth >= statComponent.maxHealth)
-            {
-                statComponent.currentHealth = statComponent.maxHealth;
-            }
-            ObjectPool.Destroy("HealingPill", gameObject);
-        }
-    }
+	public static void DespawnPills()
+	{
+		foreach (GameObject pill in currentPills)
+		{
+			ObjectPool.Destroy("HealingPill", pill);
+		}
+		currentPills.Clear();
+	}
+
+	void Update()
+	{
+		gameObject.transform.rotation *= Quaternion.AngleAxis(-3, Vector3.forward);
+	}
+
+	public void OnTriggerEnter(Collider other)
+	{
+		if (other.tag == "Player")
+		{
+			Stats statComponent = other.gameObject.GetComponent<Stats>();
+			statComponent.currentHealth += 15;
+			if (statComponent.currentHealth >= statComponent.maxHealth)
+			{
+				statComponent.currentHealth = statComponent.maxHealth;
+			}
+			ObjectPool.Destroy("HealingPill", gameObject);
+		}
+	}
 }

--- a/Assets/Scripts/HealingPill.cs
+++ b/Assets/Scripts/HealingPill.cs
@@ -8,7 +8,7 @@ public class HealingPill : MonoBehaviour
 
     public static GameObject SpawnPill(Vector3 position)
     {
-        GameObject newHealingPill = GameObject.Instantiate(Resources.Load("HealingPill")) as GameObject;
+        GameObject newHealingPill = ObjectPool.Create("HealingPill");
         Transform pillTransform = newHealingPill.GetComponent<Transform>();
         pillTransform.position = position;
         currentPills.Add(newHealingPill);
@@ -19,7 +19,7 @@ public class HealingPill : MonoBehaviour
     {
         foreach (GameObject pill in currentPills)
         {
-            Destroy(pill);
+            ObjectPool.Destroy("HealingPill", pill);
         }
         currentPills.Clear();
     }
@@ -38,7 +38,7 @@ public class HealingPill : MonoBehaviour
             {
                 statComponent.currentHealth = statComponent.maxHealth;
             }
-            Destroy(gameObject);
+            ObjectPool.Destroy("HealingPill", gameObject);
         }
     }
 }

--- a/Assets/Scripts/ObjectPool.cs
+++ b/Assets/Scripts/ObjectPool.cs
@@ -1,0 +1,50 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ObjectPool
+{
+	private static Dictionary<string, HashSet<GameObject>> available = new Dictionary<string, HashSet<GameObject>>();
+	private static Dictionary<string, HashSet<GameObject>> occupied = new Dictionary<string, HashSet<GameObject>>();
+	
+	public static GameObject Create(string prefab)
+	{
+		HashSet<GameObject> availableObjects;
+		available.TryGetValue(prefab, out availableObjects);
+		if (availableObjects == null)
+		{
+			available[prefab] = new HashSet<GameObject>();
+			occupied[prefab] = new HashSet<GameObject>();
+		}
+
+		GameObject provisionedObject = null;
+		if (available[prefab].Count == 0)
+		{
+			provisionedObject = GameObject.Instantiate(Resources.Load(prefab)) as GameObject;
+			occupied[prefab].Add(provisionedObject);
+		}
+		else
+		{
+			foreach (GameObject g in available[prefab])
+			{
+				provisionedObject = g;
+				break;
+			}
+			available[prefab].Remove(provisionedObject);
+			occupied[prefab].Add(provisionedObject);
+		}
+
+		provisionedObject.SetActive(true);
+		return provisionedObject;
+	}
+
+	public static void Destroy(string prefab, GameObject gameObject)
+	{
+		HashSet<GameObject> occupiedObjects;
+		occupied.TryGetValue(prefab, out occupiedObjects);
+		if (occupiedObjects == null || !occupiedObjects.Contains(gameObject)) Debug.LogError("ObjectPool: Tried to destroy non-existent prefab type " + prefab);
+		occupied[prefab].Remove(gameObject);
+		gameObject.SetActive(false);
+		available[prefab].Add(gameObject);
+	}
+}

--- a/Assets/Scripts/ObjectPool.cs
+++ b/Assets/Scripts/ObjectPool.cs
@@ -4,50 +4,50 @@ using UnityEngine;
 
 public class ObjectPool
 {
-    private static Dictionary<string, HashSet<GameObject>> available = new Dictionary<string, HashSet<GameObject>>();
-    private static Dictionary<string, HashSet<GameObject>> occupied = new Dictionary<string, HashSet<GameObject>>();
+	private static Dictionary<string, HashSet<GameObject>> available = new Dictionary<string, HashSet<GameObject>>();
+	private static Dictionary<string, HashSet<GameObject>> occupied = new Dictionary<string, HashSet<GameObject>>();
 
-    public static GameObject Create(string prefab)
-    {
-        HashSet<GameObject> availableObjects;
-        available.TryGetValue(prefab, out availableObjects);
-        if (availableObjects == null)
-        {
-            available[prefab] = new HashSet<GameObject>();
-            occupied[prefab] = new HashSet<GameObject>();
-        }
+	public static GameObject Create(string prefab)
+	{
+		HashSet<GameObject> availableObjects;
+		available.TryGetValue(prefab, out availableObjects);
+		if (availableObjects == null)
+		{
+			available[prefab] = new HashSet<GameObject>();
+			occupied[prefab] = new HashSet<GameObject>();
+		}
 
-        GameObject provisionedObject = null;
-        if (available[prefab].Count == 0)
-        {
-            provisionedObject = GameObject.Instantiate(Resources.Load(prefab)) as GameObject;
-            occupied[prefab].Add(provisionedObject);
-        }
-        else
-        {
-            foreach (GameObject g in available[prefab])
-            {
-                provisionedObject = g;
-                break;
-            }
-            available[prefab].Remove(provisionedObject);
-            occupied[prefab].Add(provisionedObject);
-        }
-        
-        provisionedObject.SetActive(true);
-        return provisionedObject;
-    }
+		GameObject provisionedObject = null;
+		if (available[prefab].Count == 0)
+		{
+			provisionedObject = GameObject.Instantiate(Resources.Load(prefab)) as GameObject;
+			occupied[prefab].Add(provisionedObject);
+		}
+		else
+		{
+			foreach (GameObject g in available[prefab])
+			{
+				provisionedObject = g;
+				break;
+			}
+			available[prefab].Remove(provisionedObject);
+			occupied[prefab].Add(provisionedObject);
+		}
 
-    public static void Destroy(string prefab, GameObject gameObject)
-    {
-        HashSet<GameObject> occupiedObjects;
-        occupied.TryGetValue(prefab, out occupiedObjects);
-        if (occupiedObjects == null) Debug.LogError("ObjectPool: Tried to destroy non-existent prefab type " + prefab);
-        if (occupied[prefab].Contains(gameObject))
-        {
-            occupied[prefab].Remove(gameObject);
-            gameObject.SetActive(false);
-            available[prefab].Add(gameObject);
-        }
-    }
+		provisionedObject.SetActive(true);
+		return provisionedObject;
+	}
+
+	public static void Destroy(string prefab, GameObject gameObject)
+	{
+		HashSet<GameObject> occupiedObjects;
+		occupied.TryGetValue(prefab, out occupiedObjects);
+		if (occupiedObjects == null) Debug.LogError("ObjectPool: Tried to destroy non-existent prefab type " + prefab);
+		if (occupied[prefab].Contains(gameObject))
+		{
+			occupied[prefab].Remove(gameObject);
+			gameObject.SetActive(false);
+			available[prefab].Add(gameObject);
+		}
+	}
 }

--- a/Assets/Scripts/ObjectPool.cs
+++ b/Assets/Scripts/ObjectPool.cs
@@ -42,9 +42,12 @@ public class ObjectPool
 	{
 		HashSet<GameObject> occupiedObjects;
 		occupied.TryGetValue(prefab, out occupiedObjects);
-		if (occupiedObjects == null || !occupiedObjects.Contains(gameObject)) Debug.LogError("ObjectPool: Tried to destroy non-existent prefab type " + prefab);
-		occupied[prefab].Remove(gameObject);
-		gameObject.SetActive(false);
-		available[prefab].Add(gameObject);
+		if (occupiedObjects == null) Debug.LogError("ObjectPool: Tried to destroy non-existent prefab type " + prefab);
+		if (occupied[prefab].Contains(gameObject))
+		{
+			occupied[prefab].Remove(gameObject);
+			gameObject.SetActive(false);
+			available[prefab].Add(gameObject);
+		}
 	}
 }

--- a/Assets/Scripts/ObjectPool.cs.meta
+++ b/Assets/Scripts/ObjectPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8d5633e849f1da498fb950bee1fb946
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Stats.cs
+++ b/Assets/Scripts/Stats.cs
@@ -5,56 +5,60 @@ using UnityEngine;
 // TODO: refactor away from MonoBehaviour
 public class Stats : MonoBehaviour
 {
-    private float _currentHealth;
+	private float _currentHealth;
 
-    public float currentHealth
-    {
-        get => _currentHealth;
-        set
-        {
-            _currentHealth = value;
-            if (value <= 0 && owner == EntityType.ENEMY) {
-                EnemyBehaviour.Destroy(gameObject);
-                int rand = Random.Range(0, 20);
-                if(rand == 0)
-                {
-                    HealingPill.SpawnPill(gameObject.transform.position);
-                }
-            }
-            else if (owner == EntityType.PLAYER) {
-                _currentHealth = Mathf.Clamp(_currentHealth, 0, maxHealth);
-                UIManager.Health = _currentHealth;
-                if (_currentHealth == 0) {
-                    AudioManager.UpdateMusicAudio(1);
-                }
-                else {
-                    AudioManager.UpdateMusicAudio(_currentHealth / maxHealth);
+	public float currentHealth
+	{
+		get => _currentHealth;
+		set
+		{
+			_currentHealth = value;
+			if (value <= 0 && owner == EntityType.ENEMY)
+			{
+				EnemyBehaviour.Destroy(gameObject);
+				int rand = Random.Range(0, 20);
+				if (rand == 0)
+				{
+					HealingPill.SpawnPill(gameObject.transform.position);
+				}
+			}
+			else if (owner == EntityType.PLAYER)
+			{
+				_currentHealth = Mathf.Clamp(_currentHealth, 0, maxHealth);
+				UIManager.Health = _currentHealth;
+				if (_currentHealth == 0)
+				{
+					AudioManager.UpdateMusicAudio(1);
+				}
+				else
+				{
+					AudioManager.UpdateMusicAudio(_currentHealth / maxHealth);
 
-                }
-                AudioManager.PlayInjuryAudio();
-            }
-        }
-    }
-    public float maxHealth;
-    public EntityType owner;
-    bool dead = false;
+				}
+				AudioManager.PlayInjuryAudio();
+			}
+		}
+	}
+	public float maxHealth;
+	public EntityType owner;
+	bool dead = false;
 
-    public Stats(float maxHealth = 100f)
-    {
-        this.maxHealth = maxHealth;
-    }
+	public Stats(float maxHealth = 100f)
+	{
+		this.maxHealth = maxHealth;
+	}
 
-    void Start()
-    {
-        // TODO: refactor for more dynamic assignment
-        if (gameObject.tag == "Player")
-        {
-            owner = EntityType.PLAYER;
-            UIManager.MaxHealth = maxHealth;
-        }
-        else owner = EntityType.ENEMY;
+	void Start()
+	{
+		// TODO: refactor for more dynamic assignment
+		if (gameObject.tag == "Player")
+		{
+			owner = EntityType.PLAYER;
+			UIManager.MaxHealth = maxHealth;
+		}
+		else owner = EntityType.ENEMY;
 
-        currentHealth = maxHealth;
-    }
+		currentHealth = maxHealth;
+	}
 
 }

--- a/Assets/Scripts/Stats.cs
+++ b/Assets/Scripts/Stats.cs
@@ -14,7 +14,7 @@ public class Stats : MonoBehaviour
         {
             _currentHealth = value;
             if (value <= 0 && owner == EntityType.ENEMY) {
-                Destroy(gameObject);
+                EnemyBehaviour.Destroy(gameObject);
                 int rand = Random.Range(0, 20);
                 if(rand == 0)
                 {

--- a/Assets/Scripts/Weapons/BehaviourTypes/ArtilleryAttackBehaviour.cs
+++ b/Assets/Scripts/Weapons/BehaviourTypes/ArtilleryAttackBehaviour.cs
@@ -36,7 +36,7 @@ public class ArtilleryAttackBehaviour : BulletAttackBehaviour
                 {
                     Stats statsComponent = collider.gameObject.GetComponent<Stats>();
                     statsComponent.currentHealth -= _damage/2; // Deal half damage on explosion.
-                    GameObject.Destroy(bm.gameObject);
+                    ObjectPool.Destroy("Artillery", bm.gameObject);
                     break;
                 }
             }
@@ -50,7 +50,7 @@ public class ArtilleryAttackBehaviour : BulletAttackBehaviour
                     // Spawn the pool on the ground.
                     thermitePool.GetComponent<Transform>().position = hitInfo[i].point;
                     thermitePool.GetComponent<ThermitePoolMono>().Initialize(this);
-                    GameObject.Destroy(bm.gameObject);
+                    ObjectPool.Destroy("Artillery", bm.gameObject);
                     return;
                 }
             }

--- a/Assets/Scripts/Weapons/BehaviourTypes/ArtilleryAttackBehaviour.cs
+++ b/Assets/Scripts/Weapons/BehaviourTypes/ArtilleryAttackBehaviour.cs
@@ -20,7 +20,7 @@ public class ArtilleryAttackBehaviour : BulletAttackBehaviour
     
     public override void initiateAttack(Vector3 position, Vector3 direction)
     {
-        ArtilleryMono.create(this, position, direction);
+        ArtilleryMono.Create(this, position, direction);
     }
 
     public override void onHit(BulletMono bm, GameObject target)
@@ -36,7 +36,7 @@ public class ArtilleryAttackBehaviour : BulletAttackBehaviour
                 {
                     Stats statsComponent = collider.gameObject.GetComponent<Stats>();
                     statsComponent.currentHealth -= _damage/2; // Deal half damage on explosion.
-                    ObjectPool.Destroy("Artillery", bm.gameObject);
+                    ArtilleryMono.Destroy(bm.gameObject);
                     break;
                 }
             }
@@ -50,7 +50,7 @@ public class ArtilleryAttackBehaviour : BulletAttackBehaviour
                     // Spawn the pool on the ground.
                     thermitePool.GetComponent<Transform>().position = hitInfo[i].point;
                     thermitePool.GetComponent<ThermitePoolMono>().Initialize(this);
-                    ObjectPool.Destroy("Artillery", bm.gameObject);
+                    ArtilleryMono.Destroy(bm.gameObject);
                     return;
                 }
             }

--- a/Assets/Scripts/Weapons/BehaviourTypes/ArtilleryAttackBehaviour.cs
+++ b/Assets/Scripts/Weapons/BehaviourTypes/ArtilleryAttackBehaviour.cs
@@ -7,53 +7,53 @@ using UnityEngine;
  */
 public class ArtilleryAttackBehaviour : BulletAttackBehaviour
 {
-    public int thermiteDurability;
-    public float thermiteDamageCooldown;
+	public int thermiteDurability;
+	public float thermiteDamageCooldown;
 
 
-    public ArtilleryAttackBehaviour(EntityType owner, float damage = 5f, float bulletSpeed = 10f, int durability = 10, float damageCooldown = 0.25f)
-        : base(owner, damage, bulletSpeed)
-    {
-        thermiteDurability = durability;
-        thermiteDamageCooldown = damageCooldown;
-    }
+	public ArtilleryAttackBehaviour(EntityType owner, float damage = 5f, float bulletSpeed = 10f, int durability = 10, float damageCooldown = 0.25f)
+		: base(owner, damage, bulletSpeed)
+	{
+		thermiteDurability = durability;
+		thermiteDamageCooldown = damageCooldown;
+	}
 
-    public override void initiateAttack(Vector3 position, Vector3 direction)
-    {
-        ArtilleryMono.Create(this, position, direction);
-    }
+	public override void initiateAttack(Vector3 position, Vector3 direction)
+	{
+		ArtilleryMono.Create(this, position, direction);
+	}
 
-    public override void onHit(BulletMono bm, GameObject target)
-    {
-        if (target.tag != "Enemy" && target.tag != "Detector" && (target.tag == "Player" || target.GetComponent<BulletMono>() == null)) // if not another bullet...
-        {
-            Vector3 position = bm.gameObject.GetComponent<Transform>().position;
-            Collider[] explosionHits = Physics.OverlapSphere(position, 4f); // 4f = scale of ThermitePool/2
-            for (int i = 0; i < explosionHits.Length; i++)
-            {
-                Collider collider = explosionHits[i];
-                if (collider.gameObject.tag == "Player")
-                {
-                    Stats statsComponent = collider.gameObject.GetComponent<Stats>();
-                    statsComponent.currentHealth -= _damage / 2; // Deal half damage on explosion.
-                    ArtilleryMono.Destroy(bm.gameObject);
-                    break;
-                }
-            }
+	public override void onHit(BulletMono bm, GameObject target)
+	{
+		if (target.tag != "Enemy" && target.tag != "Detector" && (target.tag == "Player" || target.GetComponent<BulletMono>() == null)) // if not another bullet...
+		{
+			Vector3 position = bm.gameObject.GetComponent<Transform>().position;
+			Collider[] explosionHits = Physics.OverlapSphere(position, 4f); // 4f = scale of ThermitePool/2
+			for (int i = 0; i < explosionHits.Length; i++)
+			{
+				Collider collider = explosionHits[i];
+				if (collider.gameObject.tag == "Player")
+				{
+					Stats statsComponent = collider.gameObject.GetComponent<Stats>();
+					statsComponent.currentHealth -= _damage / 2; // Deal half damage on explosion.
+					ArtilleryMono.Destroy(bm.gameObject);
+					break;
+				}
+			}
 
-            RaycastHit[] hitInfo = Physics.RaycastAll(position + new Vector3(0, 5, 0), new Vector3(0, -1, 0));
-            for (int i = 0; i < hitInfo.Length; i++)
-            {
-                if (hitInfo[i].collider.gameObject.tag == "Platform")
-                {
-                    GameObject thermitePool = GameObject.Instantiate(Resources.Load("ThermitePool")) as GameObject;
-                    // Spawn the pool on the ground.
-                    thermitePool.GetComponent<Transform>().position = hitInfo[i].point;
-                    thermitePool.GetComponent<ThermitePoolMono>().Initialize(this);
-                    ArtilleryMono.Destroy(bm.gameObject);
-                    return;
-                }
-            }
-        }
-    }
+			RaycastHit[] hitInfo = Physics.RaycastAll(position + new Vector3(0, 5, 0), new Vector3(0, -1, 0));
+			for (int i = 0; i < hitInfo.Length; i++)
+			{
+				if (hitInfo[i].collider.gameObject.tag == "Platform")
+				{
+					GameObject thermitePool = GameObject.Instantiate(Resources.Load("ThermitePool")) as GameObject;
+					// Spawn the pool on the ground.
+					thermitePool.GetComponent<Transform>().position = hitInfo[i].point;
+					thermitePool.GetComponent<ThermitePoolMono>().Initialize(this);
+					ArtilleryMono.Destroy(bm.gameObject);
+					return;
+				}
+			}
+		}
+	}
 }

--- a/Assets/Scripts/Weapons/BehaviourTypes/ArtilleryMono.cs
+++ b/Assets/Scripts/Weapons/BehaviourTypes/ArtilleryMono.cs
@@ -19,7 +19,7 @@ public class ArtilleryMono : BulletMono
     // direction is actually the position of the enemy
     public static GameObject create(ArtilleryAttackBehaviour attackBehaviour, Vector3 position, Vector3 direction)
     {
-        GameObject newBullet = Instantiate(Resources.Load("Artillery")) as GameObject;
+        GameObject newBullet = ObjectPool.Create("Artillery");
 
         ArtilleryMono behaviour = newBullet.GetComponent<ArtilleryMono>();
         

--- a/Assets/Scripts/Weapons/BehaviourTypes/ArtilleryMono.cs
+++ b/Assets/Scripts/Weapons/BehaviourTypes/ArtilleryMono.cs
@@ -17,7 +17,7 @@ public class ArtilleryMono : BulletMono
     public float incrementX;
 
     // direction is actually the position of the enemy
-    public static GameObject create(ArtilleryAttackBehaviour attackBehaviour, Vector3 position, Vector3 direction)
+    public static GameObject Create(ArtilleryAttackBehaviour attackBehaviour, Vector3 position, Vector3 direction)
     {
         GameObject newBullet = ObjectPool.Create("Artillery");
 
@@ -42,6 +42,11 @@ public class ArtilleryMono : BulletMono
         behaviour.incrementX = (targetXY.x - positionXY.x)/300; 
 
         return newBullet;
+    }
+
+    public static void Destroy(GameObject artillery)
+    {
+        ObjectPool.Destroy("Artillery", artillery);
     }
 
     void Update()

--- a/Assets/Scripts/Weapons/BehaviourTypes/ArtilleryMono.cs
+++ b/Assets/Scripts/Weapons/BehaviourTypes/ArtilleryMono.cs
@@ -4,65 +4,65 @@ using UnityEngine;
 
 public class ArtilleryMono : BulletMono
 {
-    public static float vertexHeight = 40f;
+	public static float vertexHeight = 40f;
 
-    public Vector3 gpPlane;
+	public Vector3 gpPlane;
 
-    public float d;
+	public float d;
 
-    private ArtilleryAttackBehaviour _attackBehaviour;
+	private ArtilleryAttackBehaviour _attackBehaviour;
 
-    public float[] quadratic = new float[3];
+	public float[] quadratic = new float[3];
 
-    public float incrementX;
+	public float incrementX;
 
-    // direction is actually the position of the enemy
-    public static GameObject Create(ArtilleryAttackBehaviour attackBehaviour, Vector3 position, Vector3 direction)
-    {
-        GameObject newBullet = ObjectPool.Create("Artillery");
+	// direction is actually the position of the enemy
+	public static GameObject Create(ArtilleryAttackBehaviour attackBehaviour, Vector3 position, Vector3 direction)
+	{
+		GameObject newBullet = ObjectPool.Create("Artillery");
 
-        ArtilleryMono behaviour = newBullet.GetComponent<ArtilleryMono>();
+		ArtilleryMono behaviour = newBullet.GetComponent<ArtilleryMono>();
 
-        behaviour._attackBehaviour = attackBehaviour;
+		behaviour._attackBehaviour = attackBehaviour;
 
-        newBullet.transform.position = position;
+		newBullet.transform.position = position;
 
-        Vector3 vertex = position + (direction - position) / 2 + new Vector3(0, ArtilleryMono.vertexHeight, 0);
+		Vector3 vertex = position + (direction - position) / 2 + new Vector3(0, ArtilleryMono.vertexHeight, 0);
 
-        behaviour.gpPlane = MathModule.determinePlaneNormal(position, direction, vertex);
+		behaviour.gpPlane = MathModule.determinePlaneNormal(position, direction, vertex);
 
-        behaviour.d = -1 * (behaviour.gpPlane.x * position.x + behaviour.gpPlane.y * position.y + behaviour.gpPlane.z * position.z);
+		behaviour.d = -1 * (behaviour.gpPlane.x * position.x + behaviour.gpPlane.y * position.y + behaviour.gpPlane.z * position.z);
 
-        Vector3 positionXY = MathModule.convertToXY(behaviour.gpPlane, position, behaviour.d);
-        Vector3 targetXY = MathModule.convertToXY(behaviour.gpPlane, direction, behaviour.d);
-        Vector3 vertexXY = MathModule.convertToXY(behaviour.gpPlane, vertex, behaviour.d);
+		Vector3 positionXY = MathModule.convertToXY(behaviour.gpPlane, position, behaviour.d);
+		Vector3 targetXY = MathModule.convertToXY(behaviour.gpPlane, direction, behaviour.d);
+		Vector3 vertexXY = MathModule.convertToXY(behaviour.gpPlane, vertex, behaviour.d);
 
-        behaviour.quadratic = MathModule.calculateQuadratic(new Vector3[3] { positionXY, targetXY, vertexXY });
+		behaviour.quadratic = MathModule.calculateQuadratic(new Vector3[3] { positionXY, targetXY, vertexXY });
 
-        behaviour.incrementX = (targetXY.x - positionXY.x) / 300;
+		behaviour.incrementX = (targetXY.x - positionXY.x) / 300;
 
-        return newBullet;
-    }
+		return newBullet;
+	}
 
-    public static void Destroy(GameObject artillery)
-    {
-        ObjectPool.Destroy("Artillery", artillery);
-    }
+	public static void Destroy(GameObject artillery)
+	{
+		ObjectPool.Destroy("Artillery", artillery);
+	}
 
-    void Update()
-    {
-        Vector3 posXY = MathModule.convertToXY(gpPlane, transform.position, d);
+	void Update()
+	{
+		Vector3 posXY = MathModule.convertToXY(gpPlane, transform.position, d);
 
-        float nextX = posXY.x + incrementX * SpeedManager.bulletSpeedScaling;
-        float nextY = quadratic[0] * nextX * nextX + quadratic[1] * nextX + quadratic[2];
-        Vector3 newPosXY = new Vector3(nextX, nextY, 0);
-        Vector3 newPosition = MathModule.convertToPlane(gpPlane, newPosXY, d);
+		float nextX = posXY.x + incrementX * SpeedManager.bulletSpeedScaling;
+		float nextY = quadratic[0] * nextX * nextX + quadratic[1] * nextX + quadratic[2];
+		Vector3 newPosXY = new Vector3(nextX, nextY, 0);
+		Vector3 newPosition = MathModule.convertToPlane(gpPlane, newPosXY, d);
 
-        transform.position = newPosition;
-    }
+		transform.position = newPosition;
+	}
 
-    void OnTriggerEnter(Collider c)
-    {
-        _attackBehaviour.onHit(this, c.gameObject);
-    }
+	void OnTriggerEnter(Collider c)
+	{
+		_attackBehaviour.onHit(this, c.gameObject);
+	}
 }

--- a/Assets/Scripts/Weapons/BehaviourTypes/BulletMono.cs
+++ b/Assets/Scripts/Weapons/BehaviourTypes/BulletMono.cs
@@ -7,7 +7,7 @@ public class BulletMono : MonoBehaviour
 {
     private BulletAttackBehaviour _attackBehaviour;
 
-    public static GameObject create(BulletAttackBehaviour attackBehaviour, Vector3 position, Vector3 direction)
+    public static GameObject Create(BulletAttackBehaviour attackBehaviour, Vector3 position, Vector3 direction)
     {
         GameObject newBullet = ObjectPool.Create("Bullet");
 
@@ -16,9 +16,16 @@ public class BulletMono : MonoBehaviour
         newBullet.transform.position = position;
         newBullet.transform.forward = direction;
         if (attackBehaviour.Owner == EntityType.ENEMY) newBullet.GetComponent<MeshRenderer>().material.SetColor("_Color", Color.red);
-        else newBullet.GetComponent<MeshRenderer>().material.SetColor("_Color", Color.white);
 
         return newBullet;
+    }
+
+    public static void Destroy(GameObject bullet)
+    {
+        // Reset to default values
+        bullet.GetComponent<MeshRenderer>().material.SetColor("_Color", Color.white);
+        bullet.GetComponent<TrailRenderer>().Clear();
+        ObjectPool.Destroy("Bullet", bullet);
     }
 
     void Update()

--- a/Assets/Scripts/Weapons/BehaviourTypes/BulletMono.cs
+++ b/Assets/Scripts/Weapons/BehaviourTypes/BulletMono.cs
@@ -5,38 +5,38 @@ using UnityEngine;
 // Behaviour for Bullet game objects
 public class BulletMono : MonoBehaviour
 {
-    private BulletAttackBehaviour _attackBehaviour;
+	private BulletAttackBehaviour _attackBehaviour;
 
-    public static GameObject Create(BulletAttackBehaviour attackBehaviour, Vector3 position, Vector3 direction)
-    {
-        GameObject newBullet = ObjectPool.Create("Bullet");
+	public static GameObject Create(BulletAttackBehaviour attackBehaviour, Vector3 position, Vector3 direction)
+	{
+		GameObject newBullet = ObjectPool.Create("Bullet");
 
-        newBullet.GetComponent<BulletMono>()._attackBehaviour = attackBehaviour;
+		newBullet.GetComponent<BulletMono>()._attackBehaviour = attackBehaviour;
 
-        newBullet.transform.position = position;
-        newBullet.transform.forward = direction;
-        if (attackBehaviour.Owner == EntityType.ENEMY) newBullet.GetComponent<MeshRenderer>().material.SetColor("_Color", Color.red);
+		newBullet.transform.position = position;
+		newBullet.transform.forward = direction;
+		if (attackBehaviour.Owner == EntityType.ENEMY) newBullet.GetComponent<MeshRenderer>().material.SetColor("_Color", Color.red);
 
-        return newBullet;
-    }
+		return newBullet;
+	}
 
-    public static void Destroy(GameObject bullet)
-    {
-        // Reset to default values
-        bullet.GetComponent<MeshRenderer>().material.SetColor("_Color", Color.white);
-        bullet.GetComponent<TrailRenderer>().Clear();
-        ObjectPool.Destroy("Bullet", bullet);
-    }
+	public static void Destroy(GameObject bullet)
+	{
+		// Reset to default values
+		bullet.GetComponent<MeshRenderer>().material.SetColor("_Color", Color.white);
+		bullet.GetComponent<TrailRenderer>().Clear();
+		ObjectPool.Destroy("Bullet", bullet);
+	}
 
-    void Update()
-    {
-        transform.position += transform.forward * _attackBehaviour._bulletSpeed * Time.deltaTime * SpeedManager.bulletSpeedScaling;
-    }
+	void Update()
+	{
+		transform.position += transform.forward * _attackBehaviour._bulletSpeed * Time.deltaTime * SpeedManager.bulletSpeedScaling;
+	}
 
-    void OnTriggerEnter(Collider c)
-    {
-        if (c.gameObject.tag == "Detector") { if (_attackBehaviour.Owner == EntityType.ENEMY) { CrosshairUI.addIndicator(c.transform.position); } return; }
+	void OnTriggerEnter(Collider c)
+	{
+		if (c.gameObject.tag == "Detector") { if (_attackBehaviour.Owner == EntityType.ENEMY) { CrosshairUI.addIndicator(c.transform.position); } return; }
 
-        _attackBehaviour.onHit(this, c.gameObject);
-    }
+		_attackBehaviour.onHit(this, c.gameObject);
+	}
 }

--- a/Assets/Scripts/Weapons/BehaviourTypes/BulletMono.cs
+++ b/Assets/Scripts/Weapons/BehaviourTypes/BulletMono.cs
@@ -9,13 +9,14 @@ public class BulletMono : MonoBehaviour
 
     public static GameObject create(BulletAttackBehaviour attackBehaviour, Vector3 position, Vector3 direction)
     {
-        GameObject newBullet = Instantiate(Resources.Load("Bullet")) as GameObject;
+        GameObject newBullet = ObjectPool.Create("Bullet");
 
         newBullet.GetComponent<BulletMono>()._attackBehaviour = attackBehaviour;
         
         newBullet.transform.position = position;
         newBullet.transform.forward = direction;
-        if (attackBehaviour.Owner == EntityType.ENEMY)newBullet.GetComponent<MeshRenderer>().material.SetColor("_Color", Color.red);
+        if (attackBehaviour.Owner == EntityType.ENEMY) newBullet.GetComponent<MeshRenderer>().material.SetColor("_Color", Color.red);
+        else newBullet.GetComponent<MeshRenderer>().material.SetColor("_Color", Color.white);
 
         return newBullet;
     }

--- a/Assets/Scripts/Weapons/BulletAttackBehaviour.cs
+++ b/Assets/Scripts/Weapons/BulletAttackBehaviour.cs
@@ -7,50 +7,50 @@ using UnityEngine;
  */
 public class BulletAttackBehaviour : AbstractAttackBehaviour
 {
-    public float _bulletSpeed;
-    public Dictionary<string, int> _hitTypeModifiers;
-    public Dictionary<string, float> _hitStatsModifiers;
+	public float _bulletSpeed;
+	public Dictionary<string, int> _hitTypeModifiers;
+	public Dictionary<string, float> _hitStatsModifiers;
 
-    public BulletAttackBehaviour(EntityType owner, float damage = 10f, float bulletSpeed = 20f)
-        : base(owner, damage)
-    {
-        _bulletSpeed = bulletSpeed;
-        _hitTypeModifiers = new Dictionary<string, int>()
-        {
-            { "exploding", 0 },
-            { "pierceThrough", 0 }
-        };
-        _hitStatsModifiers = new Dictionary<string, float>()
-        {
-            { "damage", 0 },
-            { "bulletSpeed", 0 }
-        };
-    }
+	public BulletAttackBehaviour(EntityType owner, float damage = 10f, float bulletSpeed = 20f)
+		: base(owner, damage)
+	{
+		_bulletSpeed = bulletSpeed;
+		_hitTypeModifiers = new Dictionary<string, int>()
+		{
+			{ "exploding", 0 },
+			{ "pierceThrough", 0 }
+		};
+		_hitStatsModifiers = new Dictionary<string, float>()
+		{
+			{ "damage", 0 },
+			{ "bulletSpeed", 0 }
+		};
+	}
 
-    public override void initiateAttack(Vector3 position, Vector3 direction)
-    {
-        BulletMono.Create(this, position, direction);
-    }
+	public override void initiateAttack(Vector3 position, Vector3 direction)
+	{
+		BulletMono.Create(this, position, direction);
+	}
 
-    public virtual void onHit(BulletMono bm, GameObject target)
-    {
-        Stats statsComponent = target.GetComponent<Stats>();
-        if (statsComponent)
-        {
-            if (statsComponent.owner != _owner)
-            {
-                statsComponent.currentHealth -= _damage;
-                BulletMono.Destroy(bm.gameObject);
-                if (statsComponent.owner == EntityType.ENEMY)
-                {
-                    AudioManager.PlayImpactAudio();
-                    UIManager.DamageText(bm.gameObject.transform.position + bm.gameObject.transform.up * 0.15f, -_damage);
-                }
-            }
-        }
-        else if (target.GetComponent<BulletMono>() == null) // if not another bullet...
-        {
-            BulletMono.Destroy(bm.gameObject);
-        }
-    }
+	public virtual void onHit(BulletMono bm, GameObject target)
+	{
+		Stats statsComponent = target.GetComponent<Stats>();
+		if (statsComponent)
+		{
+			if (statsComponent.owner != _owner)
+			{
+				statsComponent.currentHealth -= _damage;
+				BulletMono.Destroy(bm.gameObject);
+				if (statsComponent.owner == EntityType.ENEMY)
+				{
+					AudioManager.PlayImpactAudio();
+					UIManager.DamageText(bm.gameObject.transform.position + bm.gameObject.transform.up * 0.15f, -_damage);
+				}
+			}
+		}
+		else if (target.GetComponent<BulletMono>() == null) // if not another bullet...
+		{
+			BulletMono.Destroy(bm.gameObject);
+		}
+	}
 }

--- a/Assets/Scripts/Weapons/BulletAttackBehaviour.cs
+++ b/Assets/Scripts/Weapons/BulletAttackBehaviour.cs
@@ -29,7 +29,7 @@ public class BulletAttackBehaviour : AbstractAttackBehaviour
 
     public override void initiateAttack(Vector3 position, Vector3 direction)
     {
-        BulletMono.create(this, position, direction);
+        BulletMono.Create(this, position, direction);
     }
 
     public virtual void onHit(BulletMono bm, GameObject target)
@@ -40,8 +40,7 @@ public class BulletAttackBehaviour : AbstractAttackBehaviour
             if (statsComponent.owner != _owner)
             {
                 statsComponent.currentHealth -= _damage;
-                bm.gameObject.GetComponent<TrailRenderer>().Clear();
-                ObjectPool.Destroy("Bullet", bm.gameObject);
+                BulletMono.Destroy(bm.gameObject);
                 if (statsComponent.owner == EntityType.ENEMY) {
                     AudioManager.PlayImpactAudio();
                     UIManager.DamageText(bm.gameObject.transform.position + bm.gameObject.transform.up * 0.15f, -_damage);
@@ -50,8 +49,7 @@ public class BulletAttackBehaviour : AbstractAttackBehaviour
         }
         else if (target.GetComponent<BulletMono>() == null) // if not another bullet...
         {
-            bm.gameObject.GetComponent<TrailRenderer>().Clear();
-            ObjectPool.Destroy("Bullet", bm.gameObject);
+            BulletMono.Destroy(bm.gameObject);
         }
     }
 }

--- a/Assets/Scripts/Weapons/BulletAttackBehaviour.cs
+++ b/Assets/Scripts/Weapons/BulletAttackBehaviour.cs
@@ -40,7 +40,8 @@ public class BulletAttackBehaviour : AbstractAttackBehaviour
             if (statsComponent.owner != _owner)
             {
                 statsComponent.currentHealth -= _damage;
-                GameObject.Destroy(bm.gameObject);
+                bm.gameObject.GetComponent<TrailRenderer>().Clear();
+                ObjectPool.Destroy("Bullet", bm.gameObject);
                 if (statsComponent.owner == EntityType.ENEMY) {
                     AudioManager.PlayImpactAudio();
                     UIManager.DamageText(bm.gameObject.transform.position + bm.gameObject.transform.up * 0.15f, -_damage);
@@ -49,7 +50,8 @@ public class BulletAttackBehaviour : AbstractAttackBehaviour
         }
         else if (target.GetComponent<BulletMono>() == null) // if not another bullet...
         {
-            GameObject.Destroy(bm.gameObject);
+            bm.gameObject.GetComponent<TrailRenderer>().Clear();
+            ObjectPool.Destroy("Bullet", bm.gameObject);
         }
     }
 }


### PR DESCRIPTION
Bullets and Artillery are now pooled for performance. When either is requested, an object pulled from an available pool- if there is none available, a new object is created and added to the pool.

Syntax for requesting any prefab:
ObjectPool.Create(string prefabName)

destroying any prefab:
ObjectPool.Destroy(string prefabName, GameObject gameObject)

To see the effects of this, watch the Hierarchy list while the game is in play. Bullets grey out when "destroyed" as they are set inactive and placed in the available pool, then become white again as they are set active and reused.

closes #114 