### PR TITLE
Fix incorrect stats owners on enemies

### DIFF
--- a/Assets/Resources/Grenadier.prefab
+++ b/Assets/Resources/Grenadier.prefab
@@ -113,7 +113,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxHealth: 30
-  owner: 1
+  owner: 0
 --- !u!195 &-8702765108055079227
 NavMeshAgent:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/MeleeTank.prefab
+++ b/Assets/Resources/MeleeTank.prefab
@@ -214,7 +214,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxHealth: 200
-  owner: 1
+  owner: 0
 --- !u!1 &6749158905559539591
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Globals.cs
+++ b/Assets/Scripts/Globals.cs
@@ -129,8 +129,8 @@ public enum EnemyVariantType
 
 public enum EntityType
 {
+	ENEMY,
 	PLAYER,
-	ENEMY
 }
 
 public enum PowerUpType


### PR DESCRIPTION
The owner property on some enemies were not set to enemy. This in addition to the OnEnable change setting current hp to max hp, AND UIManager setting the speed ratio caused the player's hp to seem to be chunked at the beginning.