### PR TITLE
Add enemy look rotation when immobile

### DIFF
--- a/Assets/Scripts/Enemy/EnemyBehaviour.cs
+++ b/Assets/Scripts/Enemy/EnemyBehaviour.cs
@@ -49,6 +49,8 @@ public class EnemyBehaviour : MonoBehaviour
 		GetAimDirection = info.aim;
 		info.navAgentSetup(new Vector3(0, 0, 0));
 
+		lastPosition = transform.position;
+		
 		return true;
 	}
 
@@ -60,18 +62,28 @@ public class EnemyBehaviour : MonoBehaviour
 		ObjectPool.Destroy(Globals.enemyPrefabNames[type], enemy);
 	}
 
+	private Vector3 lastPosition;
+
 	// Update is called once per frame
 	void Update()
 	{
 		if (!_initialized) return;
 
 		Animation anim = gameObject.transform.childCount > 0 ? gameObject.transform.GetChild(0).GetComponent<Animation>() : null;
-		// Look. Determine look direction.
-		// _direction = (_targetTransform.position - transform.position).normalized;
-		// _direction.y = 0;
-		// _lookRotation = Quaternion.LookRotation(_direction);
-		// transform.rotation = _lookRotation;
+		
+		// Look. Determine look direction. Only do this if we haven't moved to not interfere with NavAgent.
+		if (transform.position == lastPosition)
+		{
+			_direction = (_targetTransform.position - transform.position).normalized;
+			_direction.y = 0;
+			// To change maximum rotation speed, lower 360f.
+			Vector3 newDirection = Vector3.RotateTowards(transform.forward, _direction, Mathf.Deg2Rad*360f*Time.deltaTime, 100f);
+			_lookRotation = Quaternion.LookRotation(newDirection);
+			transform.rotation = _lookRotation;
+		}
 
+		lastPosition = transform.position;
+		
 		NavAgentMove(this.gameObject, _targetTransform.position);
 
 		// Aim. Determine firing direction.


### PR DESCRIPTION
When enemies haven't moved, they will rotate to look at the player. Currently the rotation is 360 degrees, so enemies will instantly rotate.

Closes #165 