### PR TITLE
Fix pills overhealing

### DIFF
--- a/Assets/Scripts/Player/PlayerCentral.cs
+++ b/Assets/Scripts/Player/PlayerCentral.cs
@@ -122,9 +122,12 @@ public class PlayerCentral : MonoBehaviour
 		//Healing Pill
 		if (Input.GetKeyDown(KeyCode.Q) && healingPills > 0) 
 		{
-			healingPills -= 1;
-			_player.GetComponent<Stats>().currentHealth += 15;
-		
+			Stats statsComponent = _player.GetComponent<Stats>();
+			if (statsComponent.currentHealth < statsComponent.maxHealth)
+			{
+				healingPills -= 1;
+				statsComponent.currentHealth = Mathf.Min(statsComponent.maxHealth, statsComponent.currentHealth + 15);
+			}
 		}
 
 


### PR DESCRIPTION
Now, healing pills will only be used if under 100% hp, and pill healing will only heal to maximum hp.
Closes #177 