### PR TITLE
Fix healers attempting to attain LOS position forever

### DIFF
--- a/Assets/Scripts/Enemy/EnemyMovements.cs
+++ b/Assets/Scripts/Enemy/EnemyMovements.cs
@@ -136,7 +136,7 @@ public static class EnemyMovements
 
 			vectorToEnemy.y = 0;
 			Vector3 newPosition = (Quaternion.AngleAxis(angle, Vector3.up) * vectorToEnemy) * 40 + playerPosition;
-			while (!CheckLOS(playerPosition, newPosition))
+			for (int i = 0; i < 5 && !CheckLOS(playerPosition, newPosition); i++)
 			{
 				angle = UnityEngine.Random.Range(-90, 90);
 				newPosition = (Quaternion.AngleAxis(angle, Vector3.up) * vectorToEnemy) * 40 + playerPosition;


### PR DESCRIPTION
Healers attempt to find a new position within LOS if their destination is not in LOS, this wasn't capped, so if you removed every location within LOS the game would freeze as it infinitely loops trying to find one.

Closes #175 