### PR TITLE
reset adrenalin modifier to reflect proper value

### DIFF
--- a/Assets/Scripts/Player/PlayerCentral.cs
+++ b/Assets/Scripts/Player/PlayerCentral.cs
@@ -56,6 +56,8 @@ public class PlayerCentral : MonoBehaviour
         _weapon = _player.AddComponent<Weapon>();
         _weapon.Initialize(new BulletAttackBehaviour(EntityType.PLAYER, damage: 10f, bulletSpeed:45f), 0.2f, 16, 1f);
 
+        SpeedManager.adrenalinModifier = 0f;
+
 		foreach (PowerUpType powerUp in Globals.TransitionPowerUpDictionary.Keys)
 		{
 			for (int i = 0; i < Globals.TransitionPowerUpDictionary[powerUp]; i++)


### PR DESCRIPTION
Changes
* reset adrenalin modifier on player start, since applying the powerups will increment it to the correct number


Note
the bug came from continuously incrementing static adrenalinModifier in SpeedManager when we transition levels.

closes #159 