### PR TITLE
thresholds, bullet speed, spawn probabilities, enemy quantity

### DIFF
--- a/Assets/Scripts/Enemy/SpawnManager.cs
+++ b/Assets/Scripts/Enemy/SpawnManager.cs
@@ -15,12 +15,12 @@ public static class SpawnManager {
 	// private static int[,] _tankSpawnChances = {{0, 0, 5, 0}, {5, 5, 10, 10}, {10, 10, 10, 10}};
 
 
-	private static int[,] _grenadierSpawnChances = {{20, 15, 30, 30, 30, 30}, {20, 15, 30, 30, 30, 30}, {20, 15, 30, 30, 30, 30}};
-	private static int[,] _flyingSpawnChances 	 = {{10, 10, 10, 10, 10, 10}, {10, 10, 10, 10, 10, 10}, {10, 10, 10, 10, 10, 10}};
-	private static int[,] _rangedSpawnChances    = {{40, 35, 30, 30, 30, 30}, {40, 35, 30, 30, 30, 30}, {40, 35, 30, 30, 30, 30}};
-	private static int[,] _tankSpawnChances 	 = {{0,  10,  5,  5, 10, 10}, {0,  10,  5,  5, 10, 10}, {0,  10,  5,  5, 10, 10}};
-	private static int[,] _turretSpawnChances    = {{30, 25, 20, 20, 15, 15}, {30, 25, 20, 20, 15, 15}, {30, 25, 20, 20, 15, 15}};
-	private static int[,] _healerSpawnChances    = {{0,   5,  5,  5,  5,  5}, {0,   5,  5,  5,  5,  5}, {0,   5,  5,  5,  5,  5}};
+	private static int[,] _grenadierSpawnChances = {{20, 25, 25, 30, 30, 30}, {25, 30, 30, 30, 30, 30}, {30, 35, 35, 30, 30, 30}};
+	private static int[,] _flyingSpawnChances 	 = {{10, 14, 14, 10, 10, 10}, {15, 15, 10, 10, 10, 10}, {10, 15, 15, 10, 10, 10}};
+	private static int[,] _rangedSpawnChances    = {{40, 35, 29, 30, 30, 30}, {28, 23, 23, 30, 30, 30}, {28, 23, 23, 30, 30, 30}};
+	private static int[,] _tankSpawnChances 	 = {{0,  0,  5,  0, 0, 10},   {5,  5,  10,  5, 10, 10}, {10, 10, 10,  5, 10, 10}};
+	private static int[,] _turretSpawnChances    = {{30, 25, 25, 20, 15, 15}, {25, 25, 25, 20, 15, 15}, {20, 15, 15, 20, 15, 15}};
+	private static int[,] _healerSpawnChances    = {{0,   1,  2,  5,  5,  5}, {2,   2,  2,  5,  5,  5}, {2,   2,  2,  5,  5,  5}};
 
 	private static Dictionary<EnemyType, int[,]> enemySpawnChances = new Dictionary<EnemyType, int[,]>() {
 		{EnemyType.GRENADIER, _grenadierSpawnChances},

--- a/Assets/Scripts/Enemy/WaveManager.cs
+++ b/Assets/Scripts/Enemy/WaveManager.cs
@@ -19,7 +19,7 @@ public class WaveManager : MonoBehaviour
 	private float waveStartTime;
 	private float waveEndTime;
 
-	private int totalWaveNumber = 3;
+	private int totalWaveNumber = 4;
 	private int enemiesPerWave = 10;
 	private const int spawnInterval = 0;
 	private int enemiesSpawned = 0;
@@ -33,6 +33,7 @@ public class WaveManager : MonoBehaviour
 	void Start()
 	{
 		if (LevelTransition.currentLevel == maxLevelNumber) _infinite = true;
+		enemiesPerWave += (LevelTransition.progression - 1) * 5;
 		transition = transform.GetChild(0).GetComponent<LevelTransition>();
 		player = GameObject.FindGameObjectWithTag("Player");
 		pum = player.GetComponent<PowerUpManager>();

--- a/Assets/Scripts/LevelTransition.cs
+++ b/Assets/Scripts/LevelTransition.cs
@@ -9,7 +9,7 @@ public class LevelTransition : MonoBehaviour
 
 	public int transitionTo = 0;
 	public static int[] Levels;
-	private static int progression = 0;
+	public static int progression = 0;
 
 	public static int currentLevel = 1;
 	public static int maxLevel = 5;

--- a/Assets/Scripts/Player/PlayerCentral.cs
+++ b/Assets/Scripts/Player/PlayerCentral.cs
@@ -54,7 +54,7 @@ public class PlayerCentral : MonoBehaviour
         gun = transform.GetChild(0).GetChild(0).GetChild(0).Find("gunF");
 
         _weapon = _player.AddComponent<Weapon>();
-        _weapon.Initialize(new BulletAttackBehaviour(EntityType.PLAYER, damage: 10f, bulletSpeed:45f), 0.2f, 16, 1f);
+        _weapon.Initialize(new BulletAttackBehaviour(EntityType.PLAYER, damage: 10f, bulletSpeed:50f), 0.2f, 16, 1f);
 
         SpeedManager.adrenalinModifier = 0f;
 

--- a/Assets/Scripts/PowerUps/PowerUpManager.cs
+++ b/Assets/Scripts/PowerUps/PowerUpManager.cs
@@ -76,9 +76,8 @@ public class PowerUpManager : MonoBehaviour
 		// TODO: find thresholds
 		// either through a calculation based on the enemies and which wave it is,
 		// or some static number that works
-		float highThreshold = 20f;
-		float midThreshold = 40f;
-
+		float highThreshold = 45f;
+		float midThreshold = 90f;
 		// check which tier distribution for powerups we will use
 		// 0 = high, 1 = mid, 2 = low
 		int powerUpPool = waveTime < highThreshold ? 0 : waveTime < midThreshold ? 1 : 2;


### PR DESCRIPTION
Changes
* Changed spawn probabilties for each wave (3) of each level (3)
* 3 waves instead of 2
* level 1 starts with 10 enemies, level 2 starts with 15, level 3 with 20
* changed thresholds for better powerups to be more realistic